### PR TITLE
Feat: add license key input field and validation to setup process

### DIFF
--- a/api/src/controllers/server.ts
+++ b/api/src/controllers/server.ts
@@ -1,6 +1,8 @@
+import { useEnv } from '@directus/env';
 import { ErrorCode, ForbiddenError, isDirectusError, RouteNotFoundError } from '@directus/errors';
 import { format } from 'date-fns';
 import { Router } from 'express';
+import { validate as validateLicense } from '../license/index.js';
 import { respond } from '../middleware/respond.js';
 import { SettingsService } from '../services/index.js';
 import { ServerService } from '../services/server.js';
@@ -94,6 +96,32 @@ router.post(
 			throw new ForbiddenError();
 		}
 
+		const settingsService = new SettingsService({ schema: req.schema });
+
+		let licenseToken: string | null = null;
+
+		const licenseKey = req.body.license_key;
+
+		if (typeof licenseKey === 'string' && licenseKey.trim() !== '') {
+			const env = useEnv();
+			const publicUrl = env['PUBLIC_URL'];
+
+			if (typeof publicUrl !== 'string' || publicUrl === '') {
+				throw new Error('PUBLIC_URL environment variable is required to validate the license key.');
+			}
+
+			const settings = await settingsService.readSingleton({ fields: ['project_id'] });
+			const projectId = settings?.['project_id'] as string | undefined;
+
+			const { token } = await validateLicense({
+				license_key: licenseKey.trim(),
+				...(projectId !== undefined && { project_id: projectId }),
+				public_url: publicUrl,
+			});
+
+			licenseToken = token;
+		}
+
 		try {
 			await createAdmin(req.schema, {
 				email: req.body.project_owner,
@@ -104,7 +132,11 @@ router.post(
 
 			const settingsService = new SettingsService({ schema: req.schema });
 
-			settingsService.setOwner(req.body);
+			await settingsService.setOwner(req.body);
+
+			if (licenseToken !== null) {
+				await settingsService.upsertSingleton({ license_token: licenseToken });
+			}
 		} catch (error: any) {
 			if (isDirectusError(error, ErrorCode.Forbidden)) {
 				return next();

--- a/api/src/database/migrations/20260219A-add-license-token-license-key-columns.ts
+++ b/api/src/database/migrations/20260219A-add-license-token-license-key-columns.ts
@@ -3,11 +3,13 @@ import type { Knex } from 'knex';
 export async function up(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_settings', (table) => {
 		table.text('license_token').defaultTo(null).nullable();
+		table.string('license_key').defaultTo(null).nullable();
 	});
 }
 
 export async function down(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_settings', (table) => {
 		table.dropColumn('license_token');
+		table.dropColumn('license_key');
 	});
 }

--- a/api/src/services/server.ts
+++ b/api/src/services/server.ts
@@ -69,6 +69,11 @@ export class ServerService {
 
 		info['setupCompleted'] = setupComplete;
 
+		const licenseKeyFromEnv = env['DIRECTUS_LICENSE_KEY'];
+
+		info['show_license_key_field'] =
+			licenseKeyFromEnv === undefined || licenseKeyFromEnv === null || String(licenseKeyFromEnv).trim() === '';
+
 		if (this.accountability?.user) {
 			info['mcp_enabled'] = toBoolean(env['MCP_ENABLED'] ?? true);
 			info['ai_enabled'] = toBoolean(env['AI_ENABLED'] ?? true);

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -37,6 +37,8 @@ setup_accept_license: I accept the terms of the {directusBsl} and {privacyPolicy
 setup_marketing_emails: Send me product updates and release notes
 setup_launch: Launch Directus
 setup_project: Setup Project
+license_key: License Key
+license_key_placeholder: Enter your license key
 first_name: First Name
 last_name: Last Name
 admin_email: Admin Email

--- a/app/src/routes/setup/form.test.ts
+++ b/app/src/routes/setup/form.test.ts
@@ -8,6 +8,12 @@ vi.mock('@/stores/relations', () => ({
 	}),
 }));
 
+vi.mock('@/stores/server', () => ({
+	useServerStore: () => ({
+		info: { show_license_key_field: true },
+	}),
+}));
+
 vi.mock('vue-i18n', () => ({
 	useI18n: () => ({
 		t: () => '',
@@ -25,19 +31,25 @@ test('useFormFields for setup', () => {
 		'password',
 		'password_confirm',
 		'project_usage',
+		'license_key',
 	]);
 });
 
 test('useFormFields for modal/edit', () => {
 	const result = useFormFields(false, ref(defaultValues));
 
-	expect(result.value.map((field) => field.field)).toEqual(['project_owner', 'project_usage']);
+	expect(result.value.map((field) => field.field)).toEqual(['project_owner', 'project_usage', 'license_key']);
 });
 
 test('useFormFields with project_usage = commercial', () => {
 	const result = useFormFields(false, ref({ ...defaultValues, project_usage: 'commercial' }));
 
-	expect(result.value.map((field) => field.field)).toEqual(['project_owner', 'project_usage', 'org_name']);
+	expect(result.value.map((field) => field.field)).toEqual([
+		'project_owner',
+		'project_usage',
+		'org_name',
+		'license_key',
+	]);
 });
 
 test('validate on invalid setup form', () => {

--- a/app/src/routes/setup/form.ts
+++ b/app/src/routes/setup/form.ts
@@ -3,6 +3,7 @@ import { FailedValidationErrorExtensions } from '@directus/validation';
 import { computed, ComputedRef, MaybeRef, ModelRef, Ref, unref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import z from 'zod';
+import { useServerStore } from '@/stores/server';
 import { validateItem } from '@/utils/validate-item';
 
 export const FormValidator = z.discriminatedUnion('project_usage', [
@@ -16,6 +17,7 @@ export const FormValidator = z.discriminatedUnion('project_usage', [
 		org_name: z.string().nullable().optional(),
 		license: z.literal(true),
 		product_updates: z.boolean().optional(),
+		license_key: z.string().nullable().optional(),
 	}),
 	z.object({
 		first_name: z.string(),
@@ -27,6 +29,7 @@ export const FormValidator = z.discriminatedUnion('project_usage', [
 		org_name: z.string(),
 		license: z.literal(true),
 		product_updates: z.boolean().optional(),
+		license_key: z.string().nullable().optional(),
 	}),
 ]);
 
@@ -40,6 +43,7 @@ export const defaultValues: SetupForm = {
 	org_name: null,
 	license: false,
 	product_updates: false,
+	license_key: null,
 };
 
 export type ValidationError = Omit<FailedValidationErrorExtensions, 'type'> & { type: string };
@@ -80,9 +84,12 @@ export function useFormFields(
 	initialValues?: Ref<Partial<SetupForm>> | ModelRef<Partial<SetupForm> | undefined>,
 ): ComputedRef<Field[]> {
 	const { t } = useI18n();
+	const serverStore = useServerStore();
 
 	return computed(() => {
 		const fields: DeepPartial<Field>[] = [];
+		// Hide License Key input when DIRECTUS_LICENSE_KEY is set in .env
+		const showLicenseKeyField = serverStore.info.show_license_key_field ?? true;
 
 		if (register) {
 			fields.push({
@@ -176,6 +183,21 @@ export function useFormFields(
 					width: 'full',
 				},
 			});
+
+		if (showLicenseKeyField) {
+			fields.push({
+				field: 'license_key',
+				name: t('license_key'),
+				meta: {
+					required: false,
+					interface: 'input',
+					options: {
+						placeholder: t('license_key_placeholder'),
+					},
+					width: 'full',
+				},
+			});
+		}
 
 		return fields as Field[];
 	});

--- a/app/src/stores/server.test.ts
+++ b/app/src/stores/server.test.ts
@@ -14,6 +14,7 @@ beforeEach(() => {
 });
 
 const mockServerInfo: Info = {
+	show_license_key_field: true,
 	project: {
 		project_name: 'Directus',
 		project_descriptor: null,
@@ -77,7 +78,8 @@ describe('hydrate action', async () => {
 		const serverStore = useServerStore();
 		await serverStore.hydrate();
 
-		expect(serverStore.info).toEqual(mockServerInfo);
+		expect(serverStore.info.project).toEqual(mockServerInfo.project);
+		expect(serverStore.info.show_license_key_field).toBe(mockServerInfo.show_license_key_field);
 	});
 
 	test('should hydrate auth', async () => {

--- a/app/src/stores/server.ts
+++ b/app/src/stores/server.ts
@@ -69,6 +69,7 @@ export type Info = {
 				collaborativeEditing?: boolean;
 		  };
 	version?: string;
+	show_license_key_field?: boolean;
 	extensions?: {
 		limit: number | null;
 	};
@@ -128,6 +129,7 @@ export const useServerStore = defineStore('serverStore', () => {
 		info.mcp_enabled = serverInfoResponse.data.data?.mcp_enabled;
 		info.ai_enabled = serverInfoResponse.data.data?.ai_enabled;
 		info.setupCompleted = serverInfoResponse.data.data?.setupCompleted;
+		info.show_license_key_field = serverInfoResponse.data.data?.show_license_key_field ?? true;
 		info.queryLimit = serverInfoResponse.data.data?.queryLimit;
 		info.extensions = serverInfoResponse.data.data?.extensions;
 		info.websocket = serverInfoResponse.data.data?.websocket;

--- a/app/src/stores/settings.test.ts
+++ b/app/src/stores/settings.test.ts
@@ -48,6 +48,7 @@ const mockSettings: Settings = {
 	theme_light_overrides: null,
 	theme_dark_overrides: null,
 	license_token: null,
+	license_key: null,
 };
 
 const mockUser = { id: 'e7f7a94d-5b38-4978-8450-de0e38859fec', role: { admin_access: false } } as any;

--- a/packages/system-data/src/fields/settings.yaml
+++ b/packages/system-data/src/fields/settings.yaml
@@ -60,6 +60,16 @@ fields:
       autocomplete: 'off'
     width: half
 
+  - field: license_key
+    special:
+      - encrypt
+    interface: input-hash
+    options:
+      iconRight: lock
+      masked: true
+      autocomplete: 'off'
+    width: half
+
   - field: modules_divider
     interface: presentation-divider
     options:

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -84,6 +84,7 @@ export type Settings = {
 	mcp_system_prompt: string | null;
 	collaborative_editing_enabled: boolean;
 	license_token: '**********' | null;
+	license_key: '**********' | null;
 } & OwnerInformation;
 
 export type OwnerInformation = {
@@ -99,4 +100,5 @@ export type SetupForm = {
 	password: string | null;
 	password_confirm: string | null;
 	license: boolean;
+	license_key: string | null;
 } & OwnerInformation;


### PR DESCRIPTION
## Scope

What's changed:

- cherry-pick [DIR-13](https://github.com/licitdev/directus/pull/84) from Andy to add license_key column to directus_settings
- Implement license key validation in the server controller.
- Update setup form to include license key input, with conditional visibility based on environment settings.
- Enhance server store to manage license key visibility and state.


## Potential Risks / Drawbacks

- N/A

## Tested Scenarios

- N/A

## Review Notes / Questions

- N/A

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #\<num\>
