### PR TITLE
Refactor license utils, add deactivate util and add validate/deactivate functionality to settings page 

### DIFF
--- a/api/src/cli/commands/license/index.test.ts
+++ b/api/src/cli/commands/license/index.test.ts
@@ -4,6 +4,7 @@ import { createTracker, MockClient } from 'knex-mock-client';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { getDatabase } from '../../../database/index.js';
 import * as license from '../../../license/index.js';
+import * as cacheTokenUtils from '../../../utils/cache-token-payload.js';
 import * as tokenUtils from '../../../utils/verify-token.js';
 import validate from './index.js';
 
@@ -15,6 +16,7 @@ vi.mock('@directus/env', () => ({
 
 vi.mock('../../../database/index.js');
 vi.mock('../../../license/index.js');
+vi.mock('../../../utils/cache-token-payload.js');
 vi.mock('../../../utils/verify-token.js');
 
 describe('CLI license validate command', () => {
@@ -66,6 +68,7 @@ describe('CLI license validate command', () => {
 
 		expect(verifyTokenMock).toHaveBeenCalledWith('jwt-token');
 		expect(tracker.history.update).toHaveLength(1);
+		expect(cacheTokenUtils.writeCacheTokenPayload).toHaveBeenCalledWith(payload);
 		expect(writeSpy).toHaveBeenCalledWith('License verified.\n');
 		expect(writeSpy).toHaveBeenCalledWith(`${JSON.stringify(payload, null, 2)}\n`);
 		expect(exitSpy).toHaveBeenCalledWith(0);
@@ -94,6 +97,7 @@ describe('CLI license validate command', () => {
 
 		expect(verifyTokenMock).toHaveBeenCalledWith('jwt-token');
 		expect(tracker.history.update).toHaveLength(1);
+		expect(cacheTokenUtils.writeCacheTokenPayload).toHaveBeenCalledWith(payload);
 		expect(writeSpy).toHaveBeenCalledWith('License verified.\n');
 		expect(exitSpy).toHaveBeenCalledWith(0);
 	});

--- a/api/src/cli/commands/license/index.test.ts
+++ b/api/src/cli/commands/license/index.test.ts
@@ -1,12 +1,14 @@
 import inquirer from 'inquirer';
 import { afterEach, beforeEach, describe, expect, type MockInstance, test, vi } from 'vitest';
 import * as license from '../../../license/index.js';
+import * as saveKeyModule from '../../../license/lib/save-key.js';
 import * as saveTokenModule from '../../../license/lib/save-token.js';
 import * as tokenUtils from '../../../utils/verify-token.js';
 import validate from './index.js';
 
 vi.mock('inquirer');
 vi.mock('../../../license/index.js');
+vi.mock('../../../license/lib/save-key.js');
 vi.mock('../../../license/lib/save-token.js');
 vi.mock('../../../utils/verify-token.js');
 
@@ -28,7 +30,7 @@ describe('CLI license validate command', () => {
 		writeSpy.mockRestore();
 	});
 
-	test('verifies license and saves token on success when key is prompted', async () => {
+	test('verifies license, saves token and key on success when key is prompted', async () => {
 		vi.mocked(inquirer.prompt).mockResolvedValue({ licenseKey: 'my-license-key' });
 
 		const validateLicenseMock = vi.fn().mockResolvedValue({ token: 'jwt-token' });
@@ -40,15 +42,16 @@ describe('CLI license validate command', () => {
 		await validate({});
 
 		expect(inquirer.prompt).toHaveBeenCalledTimes(1);
-		expect(validateLicenseMock).toHaveBeenCalledWith({ license_key: 'my-license-key' });
+		expect(validateLicenseMock).toHaveBeenCalledWith({ licenseKey: 'my-license-key' });
 		expect(tokenUtils.verify).toHaveBeenCalledWith('jwt-token');
 		expect(saveTokenModule.saveToken).toHaveBeenCalledWith('jwt-token');
+		expect(saveKeyModule.saveKey).toHaveBeenCalledWith('my-license-key');
 		expect(writeSpy).toHaveBeenCalledWith('License verified.\n');
 		expect(writeSpy).toHaveBeenCalledWith(`${JSON.stringify(payload, null, 2)}\n`);
 		expect(exitSpy).toHaveBeenCalledWith(0);
 	});
 
-	test('verifies license and saves token on success when key is passed', async () => {
+	test('verifies license, saves token and key on success when key is passed', async () => {
 		const validateLicenseMock = vi.fn().mockResolvedValue({ token: 'jwt-token' });
 		vi.mocked(license.validate).mockImplementation(validateLicenseMock);
 
@@ -58,9 +61,10 @@ describe('CLI license validate command', () => {
 		await validate({ key: 'passed-license-key' });
 
 		expect(inquirer.prompt).not.toHaveBeenCalled();
-		expect(validateLicenseMock).toHaveBeenCalledWith({ license_key: 'passed-license-key' });
+		expect(validateLicenseMock).toHaveBeenCalledWith({ licenseKey: 'passed-license-key' });
 		expect(tokenUtils.verify).toHaveBeenCalledWith('jwt-token');
 		expect(saveTokenModule.saveToken).toHaveBeenCalledWith('jwt-token');
+		expect(saveKeyModule.saveKey).toHaveBeenCalledWith('passed-license-key');
 		expect(writeSpy).toHaveBeenCalledWith('License verified.\n');
 		expect(exitSpy).toHaveBeenCalledWith(0);
 	});

--- a/api/src/cli/commands/license/index.test.ts
+++ b/api/src/cli/commands/license/index.test.ts
@@ -1,7 +1,7 @@
 import inquirer from 'inquirer';
 import knex from 'knex';
 import { createTracker, MockClient } from 'knex-mock-client';
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, type MockInstance, test, vi } from 'vitest';
 import { getDatabase } from '../../../database/index.js';
 import * as license from '../../../license/index.js';
 import * as cacheTokenUtils from '../../../utils/cache-token-payload.js';
@@ -23,13 +23,13 @@ describe('CLI license validate command', () => {
 	const db = knex({ client: MockClient });
 	const tracker = createTracker(db);
 
-	let exitSpy: any;
-	let stderrSpy: any;
-	let writeSpy: any;
+	let exitSpy: MockInstance;
+	let stderrSpy: MockInstance;
+	let writeSpy: MockInstance;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		vi.mocked(getDatabase).mockReturnValue(db as any);
+		vi.mocked(getDatabase).mockReturnValue(db);
 
 		exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
 		stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
@@ -44,7 +44,7 @@ describe('CLI license validate command', () => {
 	});
 
 	test('verifies license and updates settings on success when key is prompted', async () => {
-		vi.mocked(inquirer.prompt).mockResolvedValue({ licenseKey: 'my-license-key' } as any);
+		vi.mocked(inquirer.prompt).mockResolvedValue({ licenseKey: 'my-license-key' });
 
 		tracker.on.select('directus_settings').response([{ project_id: 'project-uuid' }]);
 		tracker.on.update('directus_settings').response(1);
@@ -63,7 +63,6 @@ describe('CLI license validate command', () => {
 		expect(validateLicenseMock).toHaveBeenCalledWith({
 			license_key: 'my-license-key',
 			project_id: 'project-uuid',
-			public_url: 'https://project.example.com',
 		});
 
 		expect(verifyTokenMock).toHaveBeenCalledWith('jwt-token');
@@ -92,7 +91,6 @@ describe('CLI license validate command', () => {
 		expect(validateLicenseMock).toHaveBeenCalledWith({
 			license_key: 'passed-license-key',
 			project_id: 'project-uuid',
-			public_url: 'https://project.example.com',
 		});
 
 		expect(verifyTokenMock).toHaveBeenCalledWith('jwt-token');
@@ -103,7 +101,7 @@ describe('CLI license validate command', () => {
 	});
 
 	test('writes error to stderr and exits 1 when validate throws', async () => {
-		vi.mocked(inquirer.prompt).mockResolvedValue({ licenseKey: 'bad-key' } as any);
+		vi.mocked(inquirer.prompt).mockResolvedValue({ licenseKey: 'bad-key' });
 
 		tracker.on.select('directus_settings').response([{ project_id: 'project-uuid' }]);
 

--- a/api/src/cli/commands/license/index.test.ts
+++ b/api/src/cli/commands/license/index.test.ts
@@ -35,9 +35,7 @@ describe('CLI license validate command', () => {
 	test('verifies license, saves token, key and project_id on success when key is prompted', async () => {
 		vi.mocked(inquirer.prompt).mockResolvedValue({ licenseKey: 'my-license-key' });
 
-		const validateLicenseMock = vi
-			.fn()
-			.mockResolvedValue({ token: 'jwt-token', projectId: 'returned-project-id' });
+		const validateLicenseMock = vi.fn().mockResolvedValue({ token: 'jwt-token', projectId: 'returned-project-id' });
 
 		vi.mocked(license.validate).mockImplementation(validateLicenseMock);
 
@@ -58,9 +56,7 @@ describe('CLI license validate command', () => {
 	});
 
 	test('verifies license, saves token and key on success when key is passed', async () => {
-		const validateLicenseMock = vi
-			.fn()
-			.mockResolvedValue({ token: 'jwt-token', projectId: 'returned-project-id' });
+		const validateLicenseMock = vi.fn().mockResolvedValue({ token: 'jwt-token', projectId: 'returned-project-id' });
 
 		vi.mocked(license.validate).mockImplementation(validateLicenseMock);
 

--- a/api/src/cli/commands/license/index.test.ts
+++ b/api/src/cli/commands/license/index.test.ts
@@ -1,110 +1,72 @@
 import inquirer from 'inquirer';
-import knex from 'knex';
-import { createTracker, MockClient } from 'knex-mock-client';
 import { afterEach, beforeEach, describe, expect, type MockInstance, test, vi } from 'vitest';
-import { getDatabase } from '../../../database/index.js';
 import * as license from '../../../license/index.js';
-import * as cacheTokenUtils from '../../../utils/cache-token-payload.js';
+import * as saveTokenModule from '../../../license/lib/save-token.js';
 import * as tokenUtils from '../../../utils/verify-token.js';
 import validate from './index.js';
 
 vi.mock('inquirer');
-
-vi.mock('@directus/env', () => ({
-	useEnv: vi.fn().mockReturnValue({ PUBLIC_URL: 'https://project.example.com' }),
-}));
-
-vi.mock('../../../database/index.js');
 vi.mock('../../../license/index.js');
-vi.mock('../../../utils/cache-token-payload.js');
+vi.mock('../../../license/lib/save-token.js');
 vi.mock('../../../utils/verify-token.js');
 
 describe('CLI license validate command', () => {
-	const db = knex({ client: MockClient });
-	const tracker = createTracker(db);
-
 	let exitSpy: MockInstance;
 	let stderrSpy: MockInstance;
 	let writeSpy: MockInstance;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		vi.mocked(getDatabase).mockReturnValue(db);
-
 		exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
 		stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 		writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
 	});
 
 	afterEach(() => {
-		tracker.reset();
 		exitSpy.mockRestore();
 		stderrSpy.mockRestore();
 		writeSpy.mockRestore();
 	});
 
-	test('verifies license and updates settings on success when key is prompted', async () => {
+	test('verifies license and saves token on success when key is prompted', async () => {
 		vi.mocked(inquirer.prompt).mockResolvedValue({ licenseKey: 'my-license-key' });
-
-		tracker.on.select('directus_settings').response([{ project_id: 'project-uuid' }]);
-		tracker.on.update('directus_settings').response(1);
 
 		const validateLicenseMock = vi.fn().mockResolvedValue({ token: 'jwt-token' });
 		vi.mocked(license.validate).mockImplementation(validateLicenseMock);
 
 		const payload = { plan: 'pro' };
-		const verifyTokenMock = vi.fn().mockResolvedValue(payload);
-		vi.mocked(tokenUtils.verify).mockImplementation(verifyTokenMock);
+		vi.mocked(tokenUtils.verify).mockResolvedValue(payload);
 
 		await validate({});
 
 		expect(inquirer.prompt).toHaveBeenCalledTimes(1);
-
-		expect(validateLicenseMock).toHaveBeenCalledWith({
-			license_key: 'my-license-key',
-			project_id: 'project-uuid',
-		});
-
-		expect(verifyTokenMock).toHaveBeenCalledWith('jwt-token');
-		expect(tracker.history.update).toHaveLength(1);
-		expect(cacheTokenUtils.writeCacheTokenPayload).toHaveBeenCalledWith(payload);
+		expect(validateLicenseMock).toHaveBeenCalledWith({ license_key: 'my-license-key' });
+		expect(tokenUtils.verify).toHaveBeenCalledWith('jwt-token');
+		expect(saveTokenModule.saveToken).toHaveBeenCalledWith('jwt-token');
 		expect(writeSpy).toHaveBeenCalledWith('License verified.\n');
 		expect(writeSpy).toHaveBeenCalledWith(`${JSON.stringify(payload, null, 2)}\n`);
 		expect(exitSpy).toHaveBeenCalledWith(0);
 	});
 
-	test('verifies license and updates settings on success when key is passed', async () => {
-		tracker.on.select('directus_settings').response([{ project_id: 'project-uuid' }]);
-		tracker.on.update('directus_settings').response(1);
-
+	test('verifies license and saves token on success when key is passed', async () => {
 		const validateLicenseMock = vi.fn().mockResolvedValue({ token: 'jwt-token' });
 		vi.mocked(license.validate).mockImplementation(validateLicenseMock);
 
 		const payload = { plan: 'pro' };
-		const verifyTokenMock = vi.fn().mockResolvedValue(payload);
-		vi.mocked(tokenUtils.verify).mockImplementation(verifyTokenMock);
+		vi.mocked(tokenUtils.verify).mockResolvedValue(payload);
 
 		await validate({ key: 'passed-license-key' });
 
 		expect(inquirer.prompt).not.toHaveBeenCalled();
-
-		expect(validateLicenseMock).toHaveBeenCalledWith({
-			license_key: 'passed-license-key',
-			project_id: 'project-uuid',
-		});
-
-		expect(verifyTokenMock).toHaveBeenCalledWith('jwt-token');
-		expect(tracker.history.update).toHaveLength(1);
-		expect(cacheTokenUtils.writeCacheTokenPayload).toHaveBeenCalledWith(payload);
+		expect(validateLicenseMock).toHaveBeenCalledWith({ license_key: 'passed-license-key' });
+		expect(tokenUtils.verify).toHaveBeenCalledWith('jwt-token');
+		expect(saveTokenModule.saveToken).toHaveBeenCalledWith('jwt-token');
 		expect(writeSpy).toHaveBeenCalledWith('License verified.\n');
 		expect(exitSpy).toHaveBeenCalledWith(0);
 	});
 
 	test('writes error to stderr and exits 1 when validate throws', async () => {
 		vi.mocked(inquirer.prompt).mockResolvedValue({ licenseKey: 'bad-key' });
-
-		tracker.on.select('directus_settings').response([{ project_id: 'project-uuid' }]);
-
 		vi.mocked(license.validate).mockRejectedValue(new Error('bad license'));
 
 		await validate({});

--- a/api/src/cli/commands/license/index.test.ts
+++ b/api/src/cli/commands/license/index.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, type MockInstance, test, vi } 
 import * as license from '../../../license/index.js';
 import * as saveKeyModule from '../../../license/lib/save-key.js';
 import * as saveTokenModule from '../../../license/lib/save-token.js';
+import * as setProjectIdModule from '../../../utils/set-project-id.js';
 import * as tokenUtils from '../../../utils/verify-token.js';
 import validate from './index.js';
 
@@ -10,6 +11,7 @@ vi.mock('inquirer');
 vi.mock('../../../license/index.js');
 vi.mock('../../../license/lib/save-key.js');
 vi.mock('../../../license/lib/save-token.js');
+vi.mock('../../../utils/set-project-id.js');
 vi.mock('../../../utils/verify-token.js');
 
 describe('CLI license validate command', () => {
@@ -30,10 +32,13 @@ describe('CLI license validate command', () => {
 		writeSpy.mockRestore();
 	});
 
-	test('verifies license, saves token and key on success when key is prompted', async () => {
+	test('verifies license, saves token, key and project_id on success when key is prompted', async () => {
 		vi.mocked(inquirer.prompt).mockResolvedValue({ licenseKey: 'my-license-key' });
 
-		const validateLicenseMock = vi.fn().mockResolvedValue({ token: 'jwt-token' });
+		const validateLicenseMock = vi
+			.fn()
+			.mockResolvedValue({ token: 'jwt-token', projectId: 'returned-project-id' });
+
 		vi.mocked(license.validate).mockImplementation(validateLicenseMock);
 
 		const payload = { plan: 'pro' };
@@ -46,13 +51,17 @@ describe('CLI license validate command', () => {
 		expect(tokenUtils.verify).toHaveBeenCalledWith('jwt-token');
 		expect(saveTokenModule.saveToken).toHaveBeenCalledWith('jwt-token');
 		expect(saveKeyModule.saveKey).toHaveBeenCalledWith('my-license-key');
+		expect(setProjectIdModule.setProjectId).toHaveBeenCalledWith('returned-project-id');
 		expect(writeSpy).toHaveBeenCalledWith('License verified.\n');
 		expect(writeSpy).toHaveBeenCalledWith(`${JSON.stringify(payload, null, 2)}\n`);
 		expect(exitSpy).toHaveBeenCalledWith(0);
 	});
 
 	test('verifies license, saves token and key on success when key is passed', async () => {
-		const validateLicenseMock = vi.fn().mockResolvedValue({ token: 'jwt-token' });
+		const validateLicenseMock = vi
+			.fn()
+			.mockResolvedValue({ token: 'jwt-token', projectId: 'returned-project-id' });
+
 		vi.mocked(license.validate).mockImplementation(validateLicenseMock);
 
 		const payload = { plan: 'pro' };
@@ -65,7 +74,23 @@ describe('CLI license validate command', () => {
 		expect(tokenUtils.verify).toHaveBeenCalledWith('jwt-token');
 		expect(saveTokenModule.saveToken).toHaveBeenCalledWith('jwt-token');
 		expect(saveKeyModule.saveKey).toHaveBeenCalledWith('passed-license-key');
+		expect(setProjectIdModule.setProjectId).toHaveBeenCalledWith('returned-project-id');
 		expect(writeSpy).toHaveBeenCalledWith('License verified.\n');
+		expect(exitSpy).toHaveBeenCalledWith(0);
+	});
+
+	test('does not call setProjectId when validateLicense returns no projectId', async () => {
+		const validateLicenseMock = vi.fn().mockResolvedValue({ token: 'jwt-token' });
+		vi.mocked(license.validate).mockImplementation(validateLicenseMock);
+
+		const payload = { plan: 'pro' };
+		vi.mocked(tokenUtils.verify).mockResolvedValue(payload);
+
+		await validate({ key: 'passed-license-key' });
+
+		expect(saveTokenModule.saveToken).toHaveBeenCalledWith('jwt-token');
+		expect(saveKeyModule.saveKey).toHaveBeenCalledWith('passed-license-key');
+		expect(setProjectIdModule.setProjectId).not.toHaveBeenCalled();
 		expect(exitSpy).toHaveBeenCalledWith(0);
 	});
 

--- a/api/src/cli/commands/license/index.ts
+++ b/api/src/cli/commands/license/index.ts
@@ -2,6 +2,7 @@ import inquirer from 'inquirer';
 import { validate as validateLicense } from '../../../license/index.js';
 import { saveKey } from '../../../license/lib/save-key.js';
 import { saveToken } from '../../../license/lib/save-token.js';
+import { setProjectId } from '../../../utils/set-project-id.js';
 import { verify } from '../../../utils/verify-token.js';
 
 export default async function validate({ key }: { key?: string }): Promise<void> {
@@ -22,11 +23,15 @@ export default async function validate({ key }: { key?: string }): Promise<void>
 			throw new Error('Invalid license key format');
 		}
 
-		const { token } = await validateLicense({ licenseKey: key });
+		const { token, projectId } = await validateLicense({ licenseKey: key });
 		const payload = await verify(token);
 
 		await saveToken(token);
 		await saveKey(key);
+
+		if (projectId) {
+			await setProjectId(projectId);
+		}
 
 		process.stdout.write('License verified.\n');
 		process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);

--- a/api/src/cli/commands/license/index.ts
+++ b/api/src/cli/commands/license/index.ts
@@ -2,6 +2,7 @@ import { useEnv } from '@directus/env';
 import inquirer from 'inquirer';
 import { getDatabase } from '../../../database/index.js';
 import { validate as validateLicense } from '../../../license/index.js';
+import { writeCacheTokenPayload } from '../../../utils/cache-token-payload.js';
 import { verify } from '../../../utils/verify-token.js';
 
 export default async function validate({ key }: { key?: string }): Promise<void> {
@@ -33,6 +34,7 @@ export default async function validate({ key }: { key?: string }): Promise<void>
 		await database('directus_settings').update({ license_token: token }).where({ project_id });
 
 		const payload = await verify(token);
+		await writeCacheTokenPayload(payload);
 
 		process.stdout.write('License verified.\n');
 		process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);

--- a/api/src/cli/commands/license/index.ts
+++ b/api/src/cli/commands/license/index.ts
@@ -1,5 +1,6 @@
 import inquirer from 'inquirer';
 import { validate as validateLicense } from '../../../license/index.js';
+import { saveKey } from '../../../license/lib/save-key.js';
 import { saveToken } from '../../../license/lib/save-token.js';
 import { verify } from '../../../utils/verify-token.js';
 
@@ -17,10 +18,15 @@ export default async function validate({ key }: { key?: string }): Promise<void>
 			key = licenseKey;
 		}
 
-		const { token } = await validateLicense({ license_key: key as string });
+		if (typeof key !== 'string') {
+			throw new Error('Invalid license key format');
+		}
+
+		const { token } = await validateLicense({ licenseKey: key });
 		const payload = await verify(token);
 
 		await saveToken(token);
+		await saveKey(key);
 
 		process.stdout.write('License verified.\n');
 		process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);

--- a/api/src/cli/commands/license/index.ts
+++ b/api/src/cli/commands/license/index.ts
@@ -1,7 +1,6 @@
 import inquirer from 'inquirer';
-import { getDatabase } from '../../../database/index.js';
 import { validate as validateLicense } from '../../../license/index.js';
-import { writeCacheTokenPayload } from '../../../utils/cache-token-payload.js';
+import { saveToken } from '../../../license/lib/save-token.js';
 import { verify } from '../../../utils/verify-token.js';
 
 export default async function validate({ key }: { key?: string }): Promise<void> {
@@ -18,15 +17,10 @@ export default async function validate({ key }: { key?: string }): Promise<void>
 			key = licenseKey;
 		}
 
-		const database = getDatabase();
-		const { project_id } = await database.select('project_id').from('directus_settings').first();
-
-		const { token } = await validateLicense({ license_key: key as string, project_id });
-
-		await database('directus_settings').update({ license_token: token }).where({ project_id });
-
+		const { token } = await validateLicense({ license_key: key as string });
 		const payload = await verify(token);
-		await writeCacheTokenPayload(payload);
+
+		await saveToken(token);
 
 		process.stdout.write('License verified.\n');
 		process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);

--- a/api/src/cli/commands/license/index.ts
+++ b/api/src/cli/commands/license/index.ts
@@ -1,4 +1,3 @@
-import { useEnv } from '@directus/env';
 import inquirer from 'inquirer';
 import { getDatabase } from '../../../database/index.js';
 import { validate as validateLicense } from '../../../license/index.js';
@@ -22,14 +21,7 @@ export default async function validate({ key }: { key?: string }): Promise<void>
 		const database = getDatabase();
 		const { project_id } = await database.select('project_id').from('directus_settings').first();
 
-		const env = useEnv();
-		const public_url = env['PUBLIC_URL'];
-
-		if (typeof public_url !== 'string' || !public_url) {
-			throw new Error('Missing or invalid PUBLIC_URL environment variable.');
-		}
-
-		const { token } = await validateLicense({ license_key: key as string, project_id, public_url });
+		const { token } = await validateLicense({ license_key: key as string, project_id });
 
 		await database('directus_settings').update({ license_token: token }).where({ project_id });
 

--- a/api/src/controllers/settings.ts
+++ b/api/src/controllers/settings.ts
@@ -1,9 +1,13 @@
 import { ErrorCode, isDirectusError } from '@directus/errors';
 import express from 'express';
+import { isNull } from 'lodash-es';
+import { deactivate, getKey, validate } from '../license/index.js';
 import { respond } from '../middleware/respond.js';
 import useCollection from '../middleware/use-collection.js';
 import { SettingsService } from '../services/settings.js';
 import asyncHandler from '../utils/async-handler.js';
+import { deleteCacheTokenPayload, writeCacheTokenPayload } from '../utils/cache-token-payload.js';
+import { verify } from '../utils/verify-token.js';
 
 const router = express.Router();
 
@@ -46,6 +50,28 @@ router.patch(
 			accountability: req.accountability,
 			schema: req.schema,
 		});
+
+		const licenseKey = req.body.license_key;
+
+		if (licenseKey && typeof licenseKey === 'string') {
+			const { token, projectId } = await validate({ licenseKey });
+			const payload = await verify(token);
+			await writeCacheTokenPayload(payload);
+			req.body.license_token = token;
+
+			if (projectId) {
+				req.body.project_id = projectId;
+			}
+		} else if (isNull(licenseKey)) {
+			const currentLicenseKey = await getKey();
+
+			if (currentLicenseKey) {
+				await deactivate({ licenseKey: currentLicenseKey });
+			}
+
+			req.body.license_token = null;
+			await deleteCacheTokenPayload();
+		}
 
 		await service.upsertSingleton(req.body);
 

--- a/api/src/license/index.ts
+++ b/api/src/license/index.ts
@@ -1,1 +1,6 @@
 export * from './lib/validate.js';
+export * from './lib/deactivate.js';
+export * from './lib/get-key.js';
+export * from './lib/get-license-payload.js';
+export * from './lib/save-key.js';
+export * from './lib/save-token.js';

--- a/api/src/license/index.ts
+++ b/api/src/license/index.ts
@@ -4,3 +4,4 @@ export * from './lib/get-key.js';
 export * from './lib/get-license-payload.js';
 export * from './lib/save-key.js';
 export * from './lib/save-token.js';
+export * from './lib/validate-and-save.js';

--- a/api/src/license/lib/deactivate.test.ts
+++ b/api/src/license/lib/deactivate.test.ts
@@ -1,0 +1,186 @@
+import { useEnv } from '@directus/env';
+import { InvalidLicenseConfigError, InvalidLicenseKeyError, ServiceUnavailableError } from '@directus/errors';
+import axios from 'axios';
+import { afterEach, expect, test, vi } from 'vitest';
+import * as getProjectIdUtils from '../../utils/get-project-id.js';
+import { deactivate } from './deactivate.js';
+
+vi.mock('@directus/env', () => ({
+	useEnv: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('axios');
+vi.mock('../../utils/get-project-id.js');
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+test('deactivate throws InvalidLicenseConfigError when LICENSE_SERVER_URL is missing', async () => {
+	vi.mocked(useEnv).mockReturnValue({});
+
+	await expect(deactivate({ licenseKey: 'key' })).rejects.toThrow(
+		'Missing or invalid license configuration. LICENSE_SERVER_URL is missing or not a string.',
+	);
+});
+
+test('deactivate throws InvalidLicenseConfigError when LICENSE_SERVER_URL is not a string', async () => {
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 123 });
+
+	await expect(deactivate({ licenseKey: 'key', projectId: 'id' })).rejects.toThrow(InvalidLicenseConfigError);
+});
+
+test('deactivate strips trailing slash from LICENSE_SERVER_URL', async () => {
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com/' });
+	vi.mocked(axios.post).mockResolvedValue({ data: { success: true } });
+
+	await deactivate({
+		licenseKey: 'my-license-key',
+		projectId: 'project-uuid',
+	});
+
+	expect(axios.post).toHaveBeenCalledWith('https://license.example.com/v1/deactivate', {
+		license_key: 'my-license-key',
+		project_id: 'project-uuid',
+	});
+});
+
+test('deactivate POSTs to /v1/deactivate with license_key and project_id when both provided', async () => {
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
+	vi.mocked(axios.post).mockResolvedValue({ data: { success: true } });
+
+	await deactivate({
+		licenseKey: 'directus-license-key',
+		projectId: 'project-uuid',
+	});
+
+	expect(getProjectIdUtils.getProjectId).not.toHaveBeenCalled();
+
+	expect(axios.post).toHaveBeenCalledWith('https://license.example.com/v1/deactivate', {
+		license_key: 'directus-license-key',
+		project_id: 'project-uuid',
+	});
+});
+
+test('deactivate resolves project_id via getProjectId when not provided', async () => {
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
+	vi.mocked(getProjectIdUtils.getProjectId).mockResolvedValue('resolved-project-id');
+	vi.mocked(axios.post).mockResolvedValue({ data: { success: true } });
+
+	await deactivate({ licenseKey: 'directus-license-key' });
+
+	expect(getProjectIdUtils.getProjectId).toHaveBeenCalledOnce();
+
+	expect(axios.post).toHaveBeenCalledWith('https://license.example.com/v1/deactivate', {
+		license_key: 'directus-license-key',
+		project_id: 'resolved-project-id',
+	});
+});
+
+test('deactivate throws InvalidLicenseConfigError when project_id cannot be resolved', async () => {
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
+	vi.mocked(getProjectIdUtils.getProjectId).mockResolvedValue(undefined);
+
+	await expect(deactivate({ licenseKey: 'directus-license-key' })).rejects.toThrow(InvalidLicenseConfigError);
+
+	expect(axios.post).not.toHaveBeenCalled();
+});
+
+test('deactivate throws when response success is false', async () => {
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
+	vi.mocked(axios.post).mockResolvedValue({ data: { success: false } });
+
+	await expect(deactivate({ licenseKey: 'directus-license-key', projectId: 'project-uuid' })).rejects.toThrow(
+		'Failed to deactivate license',
+	);
+});
+
+test('deactivate throws InvalidLicenseKeyError for 400', async () => {
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
+
+	const axiosError = Object.assign(new Error('Request failed with status code 400'), {
+		isAxiosError: true,
+		response: { data: { error: 'Bad Request' }, status: 400 },
+	});
+
+	vi.mocked(axios.post).mockRejectedValue(axiosError);
+	vi.mocked(axios.isAxiosError).mockReturnValue(true);
+
+	const err = await deactivate({
+		licenseKey: 'directus-license-key',
+		projectId: 'project-uuid',
+	}).catch((e) => e);
+
+	expect(err).toBeInstanceOf(InvalidLicenseKeyError);
+	expect(err.message).toBe('Bad Request');
+});
+
+test('deactivate throws ServiceUnavailableError for 429', async () => {
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
+
+	const axiosError = Object.assign(new Error('Request failed with status code 429'), {
+		isAxiosError: true,
+		response: { data: { error: 'Rate limit exceeded' }, status: 429 },
+	});
+
+	vi.mocked(axios.post).mockRejectedValue(axiosError);
+	vi.mocked(axios.isAxiosError).mockReturnValue(true);
+
+	const err = await deactivate({
+		licenseKey: 'directus-license-key',
+		projectId: 'project-uuid',
+	}).catch((e) => e);
+
+	expect(err).toBeInstanceOf(ServiceUnavailableError);
+	expect(err.message).toBe('Service "License Server" is unavailable. Too many requests.');
+});
+
+test('deactivate throws ServiceUnavailableError for 500 or network errors', async () => {
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
+
+	const axiosError = Object.assign(new Error('Network error'), {
+		isAxiosError: true,
+		response: undefined,
+	});
+
+	vi.mocked(axios.post).mockRejectedValue(axiosError);
+	vi.mocked(axios.isAxiosError).mockReturnValue(true);
+
+	const err = await deactivate({
+		licenseKey: 'directus-license-key',
+		projectId: 'project-uuid',
+	}).catch((e) => e);
+
+	expect(err).toBeInstanceOf(ServiceUnavailableError);
+	expect(err.message).toBe('Service "License Server" is unavailable. Network error.');
+});
+
+test('deactivate throws InvalidLicenseKeyError for other axios errors', async () => {
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
+
+	const axiosError = Object.assign(new Error('Request failed with status code 403'), {
+		isAxiosError: true,
+		response: { data: { error: 'Forbidden' }, status: 403 },
+	});
+
+	vi.mocked(axios.post).mockRejectedValue(axiosError);
+	vi.mocked(axios.isAxiosError).mockReturnValue(true);
+
+	const err = await deactivate({
+		licenseKey: 'directus-license-key',
+		projectId: 'project-uuid',
+	}).catch((e) => e);
+
+	expect(err).toBeInstanceOf(InvalidLicenseKeyError);
+	expect(err.message).toBe('Forbidden');
+});
+
+test('deactivate rethrows non-Axios errors', async () => {
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
+
+	vi.mocked(axios.post).mockRejectedValue(new Error('Connection refused'));
+
+	await expect(deactivate({ licenseKey: 'directus-license-key', projectId: 'project-uuid' })).rejects.toThrow(
+		'Connection refused',
+	);
+});

--- a/api/src/license/lib/deactivate.ts
+++ b/api/src/license/lib/deactivate.ts
@@ -2,26 +2,23 @@ import { useEnv } from '@directus/env';
 import {
 	InvalidLicenseConfigError,
 	InvalidLicenseKeyError,
-	InvalidLicenseTokenError,
 	isDirectusError,
 	ServiceUnavailableError,
 } from '@directus/errors';
-import type { AxiosError } from 'axios';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { getProjectId } from '../../utils/get-project-id.js';
-import type { ValidateLicenseRequest, ValidateLicenseResponse } from '../types/index.js';
+import type { DeactivateLicenseRequest, DeactivateLicenseResponse } from '../types/index.js';
 
-export async function validate({
-	licenseKey,
-	projectId,
-	publicUrl,
-}: ValidateLicenseRequest): Promise<ValidateLicenseResponse> {
+export async function deactivate({ licenseKey, projectId }: DeactivateLicenseRequest): Promise<void> {
 	const env = useEnv();
 	const url = env['LICENSE_SERVER_URL'];
 
 	if (typeof url !== 'string' || !url) {
 		throw new InvalidLicenseConfigError({ reason: 'LICENSE_SERVER_URL is missing or not a string' });
 	}
+
+	const baseUrl = url.replace(/\/$/, '');
+	const deactivateUrl = `${baseUrl}/v1/deactivate`;
 
 	if (!projectId) {
 		const storedProjectId = await getProjectId();
@@ -33,33 +30,17 @@ export async function validate({
 		projectId = storedProjectId;
 	}
 
-	if (!publicUrl) {
-		const envPublicUrl = env['PUBLIC_URL'];
-
-		if (typeof envPublicUrl !== 'string' || !envPublicUrl) {
-			throw new InvalidLicenseConfigError({ reason: 'PUBLIC_URL is missing or not a string' });
-		}
-
-		publicUrl = envPublicUrl;
-	}
-
-	const baseUrl = url.replace(/\/$/, '');
-	const verifyUrl = `${baseUrl}/v1/validate`;
-
 	try {
-		const getTokenResponse = await axios.post<ValidateLicenseResponse>(verifyUrl, {
+		const response = await axios.post<DeactivateLicenseResponse>(deactivateUrl, {
 			license_key: licenseKey,
 			project_id: projectId,
-			public_url: publicUrl,
 		});
 
-		const { token, projectId: newProjectId } = getTokenResponse.data;
+		const { success } = response.data;
 
-		if (typeof token !== 'string' || !token) {
-			throw new InvalidLicenseTokenError();
+		if (!success) {
+			throw new Error('Failed to deactivate license');
 		}
-
-		return { token, projectId: newProjectId };
 	} catch (error) {
 		if (isDirectusError(error)) throw error;
 		if (!axios.isAxiosError(error)) throw error;

--- a/api/src/license/lib/get-feature.test.ts
+++ b/api/src/license/lib/get-feature.test.ts
@@ -22,7 +22,7 @@ describe('getFeature', () => {
 			},
 		};
 
-		vi.mocked(getLicensePayload).mockResolvedValue(cachedPayload as any);
+		vi.mocked(getLicensePayload).mockResolvedValue(cachedPayload);
 
 		const result = await getFeature('featureA');
 
@@ -30,7 +30,7 @@ describe('getFeature', () => {
 	});
 
 	test('throws when license payload is not found', async () => {
-		vi.mocked(getLicensePayload).mockResolvedValue(undefined as any);
+		vi.mocked(getLicensePayload).mockResolvedValue(undefined);
 
 		await expect(getFeature('featureA')).rejects.toThrow('License payload is not found');
 	});
@@ -44,7 +44,7 @@ describe('getFeature', () => {
 			},
 		};
 
-		vi.mocked(getLicensePayload).mockResolvedValue(cachedPayload as any);
+		vi.mocked(getLicensePayload).mockResolvedValue(cachedPayload);
 
 		await expect(getFeature('missingFeature')).rejects.toThrow(
 			'Feature "missingFeature" does not exist in license entitlements',

--- a/api/src/license/lib/get-feature.test.ts
+++ b/api/src/license/lib/get-feature.test.ts
@@ -14,28 +14,30 @@ afterEach(() => {
 });
 
 describe('getFeature', () => {
-	test('throws when path is empty', async () => {
-		await expect(getFeature('')).rejects.toThrow('Feature path must not be empty');
+	test('throws when feature name is empty', async () => {
+		await expect(getFeature('')).rejects.toThrow('Feature name must not be empty');
 	});
 
-	test('returns value from cached payload when available', async () => {
+	test('returns feature data from cached payload when available', async () => {
 		const cachedPayload = {
-			features: {
-				myFeature: 'enabled',
+			metadata: {
+				entitlements: {
+					featureA: { key1: 'value1' },
+				},
 			},
 		};
 
 		vi.mocked(readCacheTokenPayload).mockResolvedValue(cachedPayload as any);
 
-		const result = await getFeature('features.myFeature');
+		const result = await getFeature('featureA');
 
-		expect(result).toBe('enabled');
+		expect(result).toEqual({ key1: 'value1' });
 		expect(getDatabase).not.toHaveBeenCalled();
 		expect(verify).not.toHaveBeenCalled();
 		expect(writeCacheTokenPayload).not.toHaveBeenCalled();
 	});
 
-	test('loads payload from database, verifies token, caches it and returns feature', async () => {
+	test('loads payload from database, verifies token, caches it and returns feature data', async () => {
 		vi.mocked(readCacheTokenPayload).mockResolvedValue(undefined);
 
 		const first = vi.fn().mockResolvedValue({ license_token: 'jwt-token' });
@@ -49,14 +51,16 @@ describe('getFeature', () => {
 		vi.mocked(getDatabase).mockReturnValue(db as any);
 
 		const verifiedPayload = {
-			features: {
-				myFeature: 123,
+			metadata: {
+				entitlements: {
+					featureA: { key1: 'value1' },
+				},
 			},
 		};
 
 		vi.mocked(verify).mockResolvedValue(verifiedPayload as any);
 
-		const result = await getFeature('features.myFeature');
+		const result = await getFeature('featureA');
 
 		expect(getDatabase).toHaveBeenCalled();
 		expect(db.select).toHaveBeenCalledWith('license_token');
@@ -64,7 +68,7 @@ describe('getFeature', () => {
 		expect(first).toHaveBeenCalled();
 		expect(verify).toHaveBeenCalledWith('jwt-token');
 		expect(writeCacheTokenPayload).toHaveBeenCalledWith(verifiedPayload);
-		expect(result).toBe(123);
+		expect(result).toEqual({ key1: 'value1' });
 	});
 
 	test('throws InvalidLicenseTokenError when token verification fails', async () => {
@@ -82,7 +86,7 @@ describe('getFeature', () => {
 
 		vi.mocked(verify).mockRejectedValue(new Error('invalid token'));
 
-		await expect(getFeature('features.myFeature')).rejects.toThrow(InvalidLicenseTokenError);
+		await expect(getFeature('featureA')).rejects.toThrow(InvalidLicenseTokenError);
 
 		expect(writeCacheTokenPayload).not.toHaveBeenCalled();
 	});
@@ -100,21 +104,25 @@ describe('getFeature', () => {
 
 		vi.mocked(getDatabase).mockReturnValue(db as any);
 
-		await expect(getFeature('features.myFeature')).rejects.toThrow('License payload is not found');
+		await expect(getFeature('featureA')).rejects.toThrow('License payload is not found');
 
 		expect(verify).not.toHaveBeenCalled();
 		expect(writeCacheTokenPayload).not.toHaveBeenCalled();
 	});
 
-	test('throws when feature path does not exist in payload', async () => {
+	test('throws when feature does not exist in entitlements', async () => {
 		const cachedPayload = {
-			features: {
-				otherFeature: true,
+			metadata: {
+				entitlements: {
+					otherFeature: { key1: 'value1' },
+				},
 			},
 		};
 
 		vi.mocked(readCacheTokenPayload).mockResolvedValue(cachedPayload as any);
 
-		await expect(getFeature('features.missingFeature')).rejects.toThrow('Feature path does not exist: ${path}');
+		await expect(getFeature('missingFeature')).rejects.toThrow(
+			'Feature "missingFeature" does not exist in license entitlements',
+		);
 	});
 });

--- a/api/src/license/lib/get-feature.test.ts
+++ b/api/src/license/lib/get-feature.test.ts
@@ -1,13 +1,8 @@
-import { InvalidLicenseTokenError } from '@directus/errors';
 import { afterEach, describe, expect, test, vi } from 'vitest';
-import { getDatabase } from '../../database/index.js';
-import { readCacheTokenPayload, writeCacheTokenPayload } from '../../utils/cache-token-payload.js';
-import { verify } from '../../utils/verify-token.js';
 import { getFeature } from './get-feature.js';
+import { getLicensePayload } from './get-license-payload.js';
 
-vi.mock('../../database/index.js');
-vi.mock('../../utils/cache-token-payload.js');
-vi.mock('../../utils/verify-token.js');
+vi.mock('./get-license-payload.js');
 
 afterEach(() => {
 	vi.clearAllMocks();
@@ -18,7 +13,7 @@ describe('getFeature', () => {
 		await expect(getFeature('')).rejects.toThrow('Feature name must not be empty');
 	});
 
-	test('returns feature data from cached payload when available', async () => {
+	test('returns feature data when payload contains the feature', async () => {
 		const cachedPayload = {
 			metadata: {
 				entitlements: {
@@ -27,87 +22,17 @@ describe('getFeature', () => {
 			},
 		};
 
-		vi.mocked(readCacheTokenPayload).mockResolvedValue(cachedPayload as any);
+		vi.mocked(getLicensePayload).mockResolvedValue(cachedPayload as any);
 
 		const result = await getFeature('featureA');
 
 		expect(result).toEqual({ key1: 'value1' });
-		expect(getDatabase).not.toHaveBeenCalled();
-		expect(verify).not.toHaveBeenCalled();
-		expect(writeCacheTokenPayload).not.toHaveBeenCalled();
-	});
-
-	test('loads payload from database, verifies token, caches it and returns feature data', async () => {
-		vi.mocked(readCacheTokenPayload).mockResolvedValue(undefined);
-
-		const first = vi.fn().mockResolvedValue({ license_token: 'jwt-token' });
-
-		const db = {
-			select: vi.fn().mockReturnThis(),
-			from: vi.fn().mockReturnThis(),
-			first,
-		};
-
-		vi.mocked(getDatabase).mockReturnValue(db as any);
-
-		const verifiedPayload = {
-			metadata: {
-				entitlements: {
-					featureA: { key1: 'value1' },
-				},
-			},
-		};
-
-		vi.mocked(verify).mockResolvedValue(verifiedPayload as any);
-
-		const result = await getFeature('featureA');
-
-		expect(getDatabase).toHaveBeenCalled();
-		expect(db.select).toHaveBeenCalledWith('license_token');
-		expect(db.from).toHaveBeenCalledWith('directus_settings');
-		expect(first).toHaveBeenCalled();
-		expect(verify).toHaveBeenCalledWith('jwt-token');
-		expect(writeCacheTokenPayload).toHaveBeenCalledWith(verifiedPayload);
-		expect(result).toEqual({ key1: 'value1' });
-	});
-
-	test('throws InvalidLicenseTokenError when token verification fails', async () => {
-		vi.mocked(readCacheTokenPayload).mockResolvedValue(undefined);
-
-		const first = vi.fn().mockResolvedValue({ license_token: 'jwt-token' });
-
-		const db = {
-			select: vi.fn().mockReturnThis(),
-			from: vi.fn().mockReturnThis(),
-			first,
-		};
-
-		vi.mocked(getDatabase).mockReturnValue(db as any);
-
-		vi.mocked(verify).mockRejectedValue(new Error('invalid token'));
-
-		await expect(getFeature('featureA')).rejects.toThrow(InvalidLicenseTokenError);
-
-		expect(writeCacheTokenPayload).not.toHaveBeenCalled();
 	});
 
 	test('throws when license payload is not found', async () => {
-		vi.mocked(readCacheTokenPayload).mockResolvedValue(null as any);
-
-		const first = vi.fn().mockResolvedValue({ license_token: null });
-
-		const db = {
-			select: vi.fn().mockReturnThis(),
-			from: vi.fn().mockReturnThis(),
-			first,
-		};
-
-		vi.mocked(getDatabase).mockReturnValue(db as any);
+		vi.mocked(getLicensePayload).mockResolvedValue(undefined as any);
 
 		await expect(getFeature('featureA')).rejects.toThrow('License payload is not found');
-
-		expect(verify).not.toHaveBeenCalled();
-		expect(writeCacheTokenPayload).not.toHaveBeenCalled();
 	});
 
 	test('throws when feature does not exist in entitlements', async () => {
@@ -119,7 +44,7 @@ describe('getFeature', () => {
 			},
 		};
 
-		vi.mocked(readCacheTokenPayload).mockResolvedValue(cachedPayload as any);
+		vi.mocked(getLicensePayload).mockResolvedValue(cachedPayload as any);
 
 		await expect(getFeature('missingFeature')).rejects.toThrow(
 			'Feature "missingFeature" does not exist in license entitlements',

--- a/api/src/license/lib/get-feature.test.ts
+++ b/api/src/license/lib/get-feature.test.ts
@@ -1,0 +1,120 @@
+import { InvalidLicenseTokenError } from '@directus/errors';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { getDatabase } from '../../database/index.js';
+import { readCacheTokenPayload, writeCacheTokenPayload } from '../../utils/cache-token-payload.js';
+import { verify } from '../../utils/verify-token.js';
+import { getFeature } from './get-feature.js';
+
+vi.mock('../../database/index.js');
+vi.mock('../../utils/cache-token-payload.js');
+vi.mock('../../utils/verify-token.js');
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+describe('getFeature', () => {
+	test('throws when path is empty', async () => {
+		await expect(getFeature('')).rejects.toThrow('Feature path must not be empty');
+	});
+
+	test('returns value from cached payload when available', async () => {
+		const cachedPayload = {
+			features: {
+				myFeature: 'enabled',
+			},
+		};
+
+		vi.mocked(readCacheTokenPayload).mockResolvedValue(cachedPayload as any);
+
+		const result = await getFeature('features.myFeature');
+
+		expect(result).toBe('enabled');
+		expect(getDatabase).not.toHaveBeenCalled();
+		expect(verify).not.toHaveBeenCalled();
+		expect(writeCacheTokenPayload).not.toHaveBeenCalled();
+	});
+
+	test('loads payload from database, verifies token, caches it and returns feature', async () => {
+		vi.mocked(readCacheTokenPayload).mockResolvedValue(undefined);
+
+		const first = vi.fn().mockResolvedValue({ license_token: 'jwt-token' });
+
+		const db = {
+			select: vi.fn().mockReturnThis(),
+			from: vi.fn().mockReturnThis(),
+			first,
+		};
+
+		vi.mocked(getDatabase).mockReturnValue(db as any);
+
+		const verifiedPayload = {
+			features: {
+				myFeature: 123,
+			},
+		};
+
+		vi.mocked(verify).mockResolvedValue(verifiedPayload as any);
+
+		const result = await getFeature('features.myFeature');
+
+		expect(getDatabase).toHaveBeenCalled();
+		expect(db.select).toHaveBeenCalledWith('license_token');
+		expect(db.from).toHaveBeenCalledWith('directus_settings');
+		expect(first).toHaveBeenCalled();
+		expect(verify).toHaveBeenCalledWith('jwt-token');
+		expect(writeCacheTokenPayload).toHaveBeenCalledWith(verifiedPayload);
+		expect(result).toBe(123);
+	});
+
+	test('throws InvalidLicenseTokenError when token verification fails', async () => {
+		vi.mocked(readCacheTokenPayload).mockResolvedValue(undefined);
+
+		const first = vi.fn().mockResolvedValue({ license_token: 'jwt-token' });
+
+		const db = {
+			select: vi.fn().mockReturnThis(),
+			from: vi.fn().mockReturnThis(),
+			first,
+		};
+
+		vi.mocked(getDatabase).mockReturnValue(db as any);
+
+		vi.mocked(verify).mockRejectedValue(new Error('invalid token'));
+
+		await expect(getFeature('features.myFeature')).rejects.toThrow(InvalidLicenseTokenError);
+
+		expect(writeCacheTokenPayload).not.toHaveBeenCalled();
+	});
+
+	test('throws when license payload is not found', async () => {
+		vi.mocked(readCacheTokenPayload).mockResolvedValue(null as any);
+
+		const first = vi.fn().mockResolvedValue({ license_token: null });
+
+		const db = {
+			select: vi.fn().mockReturnThis(),
+			from: vi.fn().mockReturnThis(),
+			first,
+		};
+
+		vi.mocked(getDatabase).mockReturnValue(db as any);
+
+		await expect(getFeature('features.myFeature')).rejects.toThrow('License payload is not found');
+
+		expect(verify).not.toHaveBeenCalled();
+		expect(writeCacheTokenPayload).not.toHaveBeenCalled();
+	});
+
+	test('throws when feature path does not exist in payload', async () => {
+		const cachedPayload = {
+			features: {
+				otherFeature: true,
+			},
+		};
+
+		vi.mocked(readCacheTokenPayload).mockResolvedValue(cachedPayload as any);
+
+		await expect(getFeature('features.missingFeature')).rejects.toThrow('Feature path does not exist: ${path}');
+	});
+});

--- a/api/src/license/lib/get-feature.ts
+++ b/api/src/license/lib/get-feature.ts
@@ -1,7 +1,7 @@
 import { get, has } from 'lodash-es';
 import { getLicensePayload } from './get-license-payload.js';
 
-export async function getFeature(featureName: string): Promise<unknown> {
+export async function getFeature(featureName: string): Promise<Record<string, unknown>> {
 	if (!featureName) {
 		throw new Error('Feature name must not be empty');
 	}
@@ -18,5 +18,5 @@ export async function getFeature(featureName: string): Promise<unknown> {
 		throw new Error(`Feature "${featureName}" does not exist in license entitlements`);
 	}
 
-	return get(payload, featurePath);
+	return get(payload, featurePath) as Record<string, unknown>;
 }

--- a/api/src/license/lib/get-feature.ts
+++ b/api/src/license/lib/get-feature.ts
@@ -18,5 +18,5 @@ export async function getFeature<T = unknown>(featureName: string): Promise<T> {
 		throw new Error(`Feature "${featureName}" does not exist in license entitlements`);
 	}
 
-	return get(payload, featurePath) as Record<string, unknown>;
+	return get(payload, featurePath) as T;
 }

--- a/api/src/license/lib/get-feature.ts
+++ b/api/src/license/lib/get-feature.ts
@@ -1,29 +1,12 @@
-import { InvalidLicenseTokenError } from '@directus/errors';
 import { get, has } from 'lodash-es';
-import { getDatabase } from '../../database/index.js';
-import { readCacheTokenPayload, writeCacheTokenPayload } from '../../utils/cache-token-payload.js';
-import { verify } from '../../utils/verify-token.js';
+import { getLicensePayload } from './get-license-payload.js';
 
-export async function getFeature(featureName: string): Promise<Record<string, unknown>> {
+export async function getFeature(featureName: string): Promise<unknown> {
 	if (!featureName) {
 		throw new Error('Feature name must not be empty');
 	}
 
-	let payload = await readCacheTokenPayload();
-
-	if (!payload) {
-		const database = getDatabase();
-		const settings = await database.select('license_token').from('directus_settings').first();
-
-		if (settings?.license_token) {
-			try {
-				payload = await verify(settings.license_token);
-				await writeCacheTokenPayload(payload);
-			} catch {
-				throw new InvalidLicenseTokenError();
-			}
-		}
-	}
+	const payload = await getLicensePayload();
 
 	if (!payload) {
 		throw new Error('License payload is not found');

--- a/api/src/license/lib/get-feature.ts
+++ b/api/src/license/lib/get-feature.ts
@@ -4,9 +4,9 @@ import { getDatabase } from '../../database/index.js';
 import { readCacheTokenPayload, writeCacheTokenPayload } from '../../utils/cache-token-payload.js';
 import { verify } from '../../utils/verify-token.js';
 
-export async function getFeature(path: string): Promise<unknown> {
-	if (!path) {
-		throw new Error('Feature path must not be empty');
+export async function getFeature(featureName: string): Promise<Record<string, unknown>> {
+	if (!featureName) {
+		throw new Error('Feature name must not be empty');
 	}
 
 	let payload = await readCacheTokenPayload();
@@ -29,9 +29,11 @@ export async function getFeature(path: string): Promise<unknown> {
 		throw new Error('License payload is not found');
 	}
 
-	if (!has(payload as object, path)) {
-		throw new Error('Feature path does not exist: ${path}');
+	const featurePath = `metadata.entitlements.${featureName}`;
+
+	if (!has(payload, featurePath)) {
+		throw new Error(`Feature "${featureName}" does not exist in license entitlements`);
 	}
 
-	return get(payload as object, path);
+	return get(payload, featurePath);
 }

--- a/api/src/license/lib/get-feature.ts
+++ b/api/src/license/lib/get-feature.ts
@@ -1,0 +1,37 @@
+import { InvalidLicenseTokenError } from '@directus/errors';
+import { get, has } from 'lodash-es';
+import { getDatabase } from '../../database/index.js';
+import { readCacheTokenPayload, writeCacheTokenPayload } from '../../utils/cache-token-payload.js';
+import { verify } from '../../utils/verify-token.js';
+
+export async function getFeature(path: string): Promise<unknown> {
+	if (!path) {
+		throw new Error('Feature path must not be empty');
+	}
+
+	let payload = await readCacheTokenPayload();
+
+	if (!payload) {
+		const database = getDatabase();
+		const settings = await database.select('license_token').from('directus_settings').first();
+
+		if (settings?.license_token) {
+			try {
+				payload = await verify(settings.license_token);
+				await writeCacheTokenPayload(payload);
+			} catch {
+				throw new InvalidLicenseTokenError();
+			}
+		}
+	}
+
+	if (!payload) {
+		throw new Error('License payload is not found');
+	}
+
+	if (!has(payload as object, path)) {
+		throw new Error('Feature path does not exist: ${path}');
+	}
+
+	return get(payload as object, path);
+}

--- a/api/src/license/lib/get-feature.ts
+++ b/api/src/license/lib/get-feature.ts
@@ -1,7 +1,7 @@
 import { get, has } from 'lodash-es';
 import { getLicensePayload } from './get-license-payload.js';
 
-export async function getFeature(featureName: string): Promise<Record<string, unknown>> {
+export async function getFeature<T = unknown>(featureName: string): Promise<T> {
 	if (!featureName) {
 		throw new Error('Feature name must not be empty');
 	}

--- a/api/src/license/lib/get-key.test.ts
+++ b/api/src/license/lib/get-key.test.ts
@@ -1,0 +1,99 @@
+import { useEnv } from '@directus/env';
+import type { Knex } from 'knex';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { getDatabase } from '../../database/index.js';
+import * as encryptUtils from '../../utils/encrypt.js';
+import * as getSecretUtils from '../../utils/get-secret.js';
+import { getKey } from './get-key.js';
+
+vi.mock('@directus/env', () => ({ useEnv: vi.fn().mockReturnValue({}) }));
+vi.mock('../../database/index.js');
+vi.mock('../../utils/encrypt.js');
+vi.mock('../../utils/get-secret.js');
+
+function createDbMock() {
+	const first = vi.fn();
+
+	const db = {
+		select: vi.fn().mockReturnThis(),
+		from: vi.fn().mockReturnThis(),
+		first,
+	} as unknown as Knex;
+
+	return { db, first };
+}
+
+describe('getKey', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test('returns DIRECTUS_LICENSE_KEY from env when it is a string', async () => {
+		vi.mocked(useEnv).mockReturnValue({ DIRECTUS_LICENSE_KEY: 'env-license-key' });
+
+		const result = await getKey();
+
+		expect(result).toBe('env-license-key');
+		expect(getDatabase).not.toHaveBeenCalled();
+		expect(encryptUtils.decrypt).not.toHaveBeenCalled();
+	});
+
+	test('decrypts license_key from database and returns it when env key is not a string', async () => {
+		vi.mocked(useEnv).mockReturnValue({});
+
+		const { db, first } = createDbMock();
+		first.mockResolvedValue({ license_key: 'encrypted-key' });
+		vi.mocked(getDatabase).mockReturnValue(db);
+		vi.mocked(getSecretUtils.getSecret).mockReturnValue('test-secret');
+		vi.mocked(encryptUtils.decrypt).mockResolvedValue('plain-license-key');
+
+		const result = await getKey();
+
+		expect(getDatabase).toHaveBeenCalled();
+		expect(db.select).toHaveBeenCalledWith('license_key');
+		expect(db.from).toHaveBeenCalledWith('directus_settings');
+		expect(first).toHaveBeenCalledOnce();
+		expect(getSecretUtils.getSecret).toHaveBeenCalled();
+		expect(encryptUtils.decrypt).toHaveBeenCalledWith('encrypted-key', 'test-secret');
+		expect(result).toBe('plain-license-key');
+	});
+
+	test('returns undefined when env key is not set and db row has no license_key', async () => {
+		vi.mocked(useEnv).mockReturnValue({});
+
+		const { db, first } = createDbMock();
+		first.mockResolvedValue({ license_key: null });
+		vi.mocked(getDatabase).mockReturnValue(db);
+
+		const result = await getKey();
+
+		expect(encryptUtils.decrypt).not.toHaveBeenCalled();
+		expect(result).toBeUndefined();
+	});
+
+	test('returns undefined when env key is not set and no settings row exists', async () => {
+		vi.mocked(useEnv).mockReturnValue({});
+
+		const { db, first } = createDbMock();
+		first.mockResolvedValue(undefined);
+		vi.mocked(getDatabase).mockReturnValue(db);
+
+		const result = await getKey();
+
+		expect(encryptUtils.decrypt).not.toHaveBeenCalled();
+		expect(result).toBeUndefined();
+	});
+
+	test('returns undefined when env key is not set and license_key is not a string', async () => {
+		vi.mocked(useEnv).mockReturnValue({});
+
+		const { db, first } = createDbMock();
+		first.mockResolvedValue({});
+		vi.mocked(getDatabase).mockReturnValue(db);
+
+		const result = await getKey();
+
+		expect(encryptUtils.decrypt).not.toHaveBeenCalled();
+		expect(result).toBeUndefined();
+	});
+});

--- a/api/src/license/lib/get-key.ts
+++ b/api/src/license/lib/get-key.ts
@@ -1,0 +1,26 @@
+import { useEnv } from '@directus/env';
+import { getDatabase } from '../../database/index.js';
+import { decrypt } from '../../utils/encrypt.js';
+import { getSecret } from '../../utils/get-secret.js';
+
+export async function getKey(): Promise<string | undefined> {
+	const env = useEnv();
+	const envKey = env['DIRECTUS_LICENSE_KEY'];
+
+	if (typeof envKey === 'string') {
+		return envKey;
+	}
+
+	const database = getDatabase();
+	const settingsRow = await database.select('license_key').from('directus_settings').first();
+	const encryptedKey = settingsRow?.license_key;
+
+	if (typeof encryptedKey !== 'string') {
+		return undefined;
+	}
+
+	const secret = getSecret();
+	const key = await decrypt(encryptedKey, secret);
+
+	return key;
+}

--- a/api/src/license/lib/get-license-payload.test.ts
+++ b/api/src/license/lib/get-license-payload.test.ts
@@ -1,0 +1,115 @@
+import { InvalidLicenseTokenError } from '@directus/errors';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { getDatabase } from '../../database/index.js';
+import { readCacheTokenPayload, writeCacheTokenPayload } from '../../utils/cache-token-payload.js';
+import { verify } from '../../utils/verify-token.js';
+import { getLicensePayload } from './get-license-payload.js';
+
+vi.mock('../../database/index.js');
+vi.mock('../../utils/cache-token-payload.js');
+vi.mock('../../utils/verify-token.js');
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+describe('getLicensePayload', () => {
+	test('returns cached payload when available', async () => {
+		const cachedPayload = { metadata: { entitlements: { featureA: {} } } };
+
+		vi.mocked(readCacheTokenPayload).mockResolvedValue(cachedPayload as any);
+
+		const result = await getLicensePayload();
+
+		expect(result).toEqual(cachedPayload);
+		expect(getDatabase).not.toHaveBeenCalled();
+		expect(verify).not.toHaveBeenCalled();
+		expect(writeCacheTokenPayload).not.toHaveBeenCalled();
+	});
+
+	test('loads payload from database, verifies token, caches it and returns it when cache is empty', async () => {
+		vi.mocked(readCacheTokenPayload).mockResolvedValue(undefined);
+
+		const first = vi.fn().mockResolvedValue({ license_token: 'jwt-token' });
+
+		const db = {
+			select: vi.fn().mockReturnThis(),
+			from: vi.fn().mockReturnThis(),
+			first,
+		};
+
+		vi.mocked(getDatabase).mockReturnValue(db as any);
+
+		const verifiedPayload = { plan: 'pro', metadata: {} };
+
+		vi.mocked(verify).mockResolvedValue(verifiedPayload as any);
+
+		const result = await getLicensePayload();
+
+		expect(getDatabase).toHaveBeenCalled();
+		expect(db.select).toHaveBeenCalledWith('license_token');
+		expect(db.from).toHaveBeenCalledWith('directus_settings');
+		expect(first).toHaveBeenCalled();
+		expect(verify).toHaveBeenCalledWith('jwt-token');
+		expect(writeCacheTokenPayload).toHaveBeenCalledWith(verifiedPayload);
+		expect(result).toEqual(verifiedPayload);
+	});
+
+	test('throws InvalidLicenseTokenError when token verification fails', async () => {
+		vi.mocked(readCacheTokenPayload).mockResolvedValue(undefined);
+
+		const first = vi.fn().mockResolvedValue({ license_token: 'jwt-token' });
+
+		const db = {
+			select: vi.fn().mockReturnThis(),
+			from: vi.fn().mockReturnThis(),
+			first,
+		};
+
+		vi.mocked(getDatabase).mockReturnValue(db as any);
+		vi.mocked(verify).mockRejectedValue(new Error('invalid token'));
+
+		await expect(getLicensePayload()).rejects.toThrow(InvalidLicenseTokenError);
+
+		expect(writeCacheTokenPayload).not.toHaveBeenCalled();
+	});
+
+	test('returns undefined when no cache and no license token in database', async () => {
+		vi.mocked(readCacheTokenPayload).mockResolvedValue(undefined);
+
+		const first = vi.fn().mockResolvedValue({ license_token: null });
+
+		const db = {
+			select: vi.fn().mockReturnThis(),
+			from: vi.fn().mockReturnThis(),
+			first,
+		};
+
+		vi.mocked(getDatabase).mockReturnValue(db as any);
+
+		const result = await getLicensePayload();
+
+		expect(verify).not.toHaveBeenCalled();
+		expect(writeCacheTokenPayload).not.toHaveBeenCalled();
+		expect(result).toBeUndefined();
+	});
+
+	test('returns undefined when no cache and settings row has no license_token key', async () => {
+		vi.mocked(readCacheTokenPayload).mockResolvedValue(undefined);
+
+		const first = vi.fn().mockResolvedValue({});
+
+		const db = {
+			select: vi.fn().mockReturnThis(),
+			from: vi.fn().mockReturnThis(),
+			first,
+		};
+
+		vi.mocked(getDatabase).mockReturnValue(db as any);
+
+		const result = await getLicensePayload();
+
+		expect(verify).not.toHaveBeenCalled();
+		expect(result).toBeUndefined();
+	});
+});

--- a/api/src/license/lib/get-license-payload.test.ts
+++ b/api/src/license/lib/get-license-payload.test.ts
@@ -1,4 +1,5 @@
 import { InvalidLicenseTokenError } from '@directus/errors';
+import type { Knex } from 'knex';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { getDatabase } from '../../database/index.js';
 import { readCacheTokenPayload, writeCacheTokenPayload } from '../../utils/cache-token-payload.js';
@@ -17,7 +18,7 @@ describe('getLicensePayload', () => {
 	test('returns cached payload when available', async () => {
 		const cachedPayload = { metadata: { entitlements: { featureA: {} } } };
 
-		vi.mocked(readCacheTokenPayload).mockResolvedValue(cachedPayload as any);
+		vi.mocked(readCacheTokenPayload).mockResolvedValue(cachedPayload);
 
 		const result = await getLicensePayload();
 
@@ -36,13 +37,13 @@ describe('getLicensePayload', () => {
 			select: vi.fn().mockReturnThis(),
 			from: vi.fn().mockReturnThis(),
 			first,
-		};
+		} as unknown as Knex;
 
-		vi.mocked(getDatabase).mockReturnValue(db as any);
+		vi.mocked(getDatabase).mockReturnValue(db);
 
 		const verifiedPayload = { plan: 'pro', metadata: {} };
 
-		vi.mocked(verify).mockResolvedValue(verifiedPayload as any);
+		vi.mocked(verify).mockResolvedValue(verifiedPayload);
 
 		const result = await getLicensePayload();
 
@@ -64,9 +65,9 @@ describe('getLicensePayload', () => {
 			select: vi.fn().mockReturnThis(),
 			from: vi.fn().mockReturnThis(),
 			first,
-		};
+		} as unknown as Knex;
 
-		vi.mocked(getDatabase).mockReturnValue(db as any);
+		vi.mocked(getDatabase).mockReturnValue(db);
 		vi.mocked(verify).mockRejectedValue(new Error('invalid token'));
 
 		await expect(getLicensePayload()).rejects.toThrow(InvalidLicenseTokenError);
@@ -83,9 +84,9 @@ describe('getLicensePayload', () => {
 			select: vi.fn().mockReturnThis(),
 			from: vi.fn().mockReturnThis(),
 			first,
-		};
+		} as unknown as Knex;
 
-		vi.mocked(getDatabase).mockReturnValue(db as any);
+		vi.mocked(getDatabase).mockReturnValue(db);
 
 		const result = await getLicensePayload();
 
@@ -103,9 +104,9 @@ describe('getLicensePayload', () => {
 			select: vi.fn().mockReturnThis(),
 			from: vi.fn().mockReturnThis(),
 			first,
-		};
+		} as unknown as Knex;
 
-		vi.mocked(getDatabase).mockReturnValue(db as any);
+		vi.mocked(getDatabase).mockReturnValue(db);
 
 		const result = await getLicensePayload();
 

--- a/api/src/license/lib/get-license-payload.test.ts
+++ b/api/src/license/lib/get-license-payload.test.ts
@@ -3,11 +3,15 @@ import type { Knex } from 'knex';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { getDatabase } from '../../database/index.js';
 import { readCacheTokenPayload, writeCacheTokenPayload } from '../../utils/cache-token-payload.js';
+import * as encryptUtils from '../../utils/encrypt.js';
+import * as getSecretUtils from '../../utils/get-secret.js';
 import { verify } from '../../utils/verify-token.js';
 import { getLicensePayload } from './get-license-payload.js';
 
 vi.mock('../../database/index.js');
 vi.mock('../../utils/cache-token-payload.js');
+vi.mock('../../utils/encrypt.js');
+vi.mock('../../utils/get-secret.js');
 vi.mock('../../utils/verify-token.js');
 
 afterEach(() => {
@@ -28,10 +32,10 @@ describe('getLicensePayload', () => {
 		expect(writeCacheTokenPayload).not.toHaveBeenCalled();
 	});
 
-	test('loads payload from database, verifies token, caches it and returns it when cache is empty', async () => {
+	test('decrypts token from database, verifies it, caches payload and returns it when cache is empty', async () => {
 		vi.mocked(readCacheTokenPayload).mockResolvedValue(undefined);
 
-		const first = vi.fn().mockResolvedValue({ license_token: 'jwt-token' });
+		const first = vi.fn().mockResolvedValue({ license_token: 'encrypted-token' });
 
 		const db = {
 			select: vi.fn().mockReturnThis(),
@@ -40,6 +44,8 @@ describe('getLicensePayload', () => {
 		} as unknown as Knex;
 
 		vi.mocked(getDatabase).mockReturnValue(db);
+		vi.mocked(getSecretUtils.getSecret).mockReturnValue('test-secret');
+		vi.mocked(encryptUtils.decrypt).mockResolvedValue('jwt-token');
 
 		const verifiedPayload = { plan: 'pro', metadata: {} };
 
@@ -51,6 +57,8 @@ describe('getLicensePayload', () => {
 		expect(db.select).toHaveBeenCalledWith('license_token');
 		expect(db.from).toHaveBeenCalledWith('directus_settings');
 		expect(first).toHaveBeenCalled();
+		expect(getSecretUtils.getSecret).toHaveBeenCalled();
+		expect(encryptUtils.decrypt).toHaveBeenCalledWith('encrypted-token', 'test-secret');
 		expect(verify).toHaveBeenCalledWith('jwt-token');
 		expect(writeCacheTokenPayload).toHaveBeenCalledWith(verifiedPayload);
 		expect(result).toEqual(verifiedPayload);
@@ -59,7 +67,7 @@ describe('getLicensePayload', () => {
 	test('throws InvalidLicenseTokenError when token verification fails', async () => {
 		vi.mocked(readCacheTokenPayload).mockResolvedValue(undefined);
 
-		const first = vi.fn().mockResolvedValue({ license_token: 'jwt-token' });
+		const first = vi.fn().mockResolvedValue({ license_token: 'encrypted-token' });
 
 		const db = {
 			select: vi.fn().mockReturnThis(),
@@ -68,10 +76,33 @@ describe('getLicensePayload', () => {
 		} as unknown as Knex;
 
 		vi.mocked(getDatabase).mockReturnValue(db);
+		vi.mocked(getSecretUtils.getSecret).mockReturnValue('test-secret');
+		vi.mocked(encryptUtils.decrypt).mockResolvedValue('jwt-token');
 		vi.mocked(verify).mockRejectedValue(new Error('invalid token'));
 
 		await expect(getLicensePayload()).rejects.toThrow(InvalidLicenseTokenError);
 
+		expect(writeCacheTokenPayload).not.toHaveBeenCalled();
+	});
+
+	test('throws InvalidLicenseTokenError when decrypt fails', async () => {
+		vi.mocked(readCacheTokenPayload).mockResolvedValue(undefined);
+
+		const first = vi.fn().mockResolvedValue({ license_token: 'encrypted-token' });
+
+		const db = {
+			select: vi.fn().mockReturnThis(),
+			from: vi.fn().mockReturnThis(),
+			first,
+		} as unknown as Knex;
+
+		vi.mocked(getDatabase).mockReturnValue(db);
+		vi.mocked(getSecretUtils.getSecret).mockReturnValue('test-secret');
+		vi.mocked(encryptUtils.decrypt).mockRejectedValue(new Error('decrypt failed'));
+
+		await expect(getLicensePayload()).rejects.toThrow(InvalidLicenseTokenError);
+
+		expect(verify).not.toHaveBeenCalled();
 		expect(writeCacheTokenPayload).not.toHaveBeenCalled();
 	});
 

--- a/api/src/license/lib/get-license-payload.ts
+++ b/api/src/license/lib/get-license-payload.ts
@@ -3,7 +3,7 @@ import { getDatabase } from '../../database/index.js';
 import { readCacheTokenPayload, writeCacheTokenPayload } from '../../utils/cache-token-payload.js';
 import { verify } from '../../utils/verify-token.js';
 
-export async function getLicensePayload(): Promise<Record<string, unknown>> {
+export async function getLicensePayload(): Promise<Record<string, unknown> | undefined> {
 	let payload = await readCacheTokenPayload();
 
 	if (!payload) {
@@ -12,8 +12,8 @@ export async function getLicensePayload(): Promise<Record<string, unknown>> {
 
 		if (settings?.license_token) {
 			try {
-				payload = (await verify(settings.license_token)) as Record<string, unknown>;
-				await writeCacheTokenPayload(payload as Record<string, any>);
+				payload = await verify(settings.license_token);
+				await writeCacheTokenPayload(payload);
 			} catch {
 				throw new InvalidLicenseTokenError();
 			}

--- a/api/src/license/lib/get-license-payload.ts
+++ b/api/src/license/lib/get-license-payload.ts
@@ -13,10 +13,11 @@ export async function getLicensePayload(): Promise<Record<string, unknown> | und
 		if (settings?.license_token) {
 			try {
 				payload = await verify(settings.license_token);
-				await writeCacheTokenPayload(payload);
 			} catch {
 				throw new InvalidLicenseTokenError();
 			}
+
+			await writeCacheTokenPayload(payload);
 		}
 	}
 

--- a/api/src/license/lib/get-license-payload.ts
+++ b/api/src/license/lib/get-license-payload.ts
@@ -1,6 +1,8 @@
 import { InvalidLicenseTokenError } from '@directus/errors';
 import { getDatabase } from '../../database/index.js';
 import { readCacheTokenPayload, writeCacheTokenPayload } from '../../utils/cache-token-payload.js';
+import { decrypt } from '../../utils/encrypt.js';
+import { getSecret } from '../../utils/get-secret.js';
 import { verify } from '../../utils/verify-token.js';
 
 export async function getLicensePayload(): Promise<Record<string, unknown> | undefined> {
@@ -12,7 +14,9 @@ export async function getLicensePayload(): Promise<Record<string, unknown> | und
 
 		if (settings?.license_token) {
 			try {
-				payload = await verify(settings.license_token);
+				const secret = getSecret();
+				const rawToken = await decrypt(settings.license_token, secret);
+				payload = await verify(rawToken);
 			} catch {
 				throw new InvalidLicenseTokenError();
 			}

--- a/api/src/license/lib/get-license-payload.ts
+++ b/api/src/license/lib/get-license-payload.ts
@@ -1,0 +1,24 @@
+import { InvalidLicenseTokenError } from '@directus/errors';
+import { getDatabase } from '../../database/index.js';
+import { readCacheTokenPayload, writeCacheTokenPayload } from '../../utils/cache-token-payload.js';
+import { verify } from '../../utils/verify-token.js';
+
+export async function getLicensePayload(): Promise<Record<string, unknown>> {
+	let payload = await readCacheTokenPayload();
+
+	if (!payload) {
+		const database = getDatabase();
+		const settings = await database.select('license_token').from('directus_settings').first();
+
+		if (settings?.license_token) {
+			try {
+				payload = (await verify(settings.license_token)) as Record<string, unknown>;
+				await writeCacheTokenPayload(payload as Record<string, any>);
+			} catch {
+				throw new InvalidLicenseTokenError();
+			}
+		}
+	}
+
+	return payload;
+}

--- a/api/src/license/lib/save-key.test.ts
+++ b/api/src/license/lib/save-key.test.ts
@@ -1,21 +1,27 @@
+import type { Knex } from 'knex';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { getDatabase } from '../../database/index.js';
+import * as encryptUtils from '../../utils/encrypt.js';
+import * as getProjectIdUtils from '../../utils/get-project-id.js';
+import * as getSecretUtils from '../../utils/get-secret.js';
 import { saveKey } from './save-key.js';
 
 vi.mock('../../database/index.js');
+vi.mock('../../utils/encrypt.js');
+vi.mock('../../utils/get-secret.js');
+vi.mock('../../utils/get-project-id.js');
 
 function createDbMock() {
-	const first = vi.fn();
 	const where = vi.fn().mockResolvedValue(undefined);
 	const update = vi.fn().mockReturnValue({ where });
 
 	const db = Object.assign((_table: string) => ({ update }), {
 		select: vi.fn().mockReturnThis(),
 		from: vi.fn().mockReturnThis(),
-		first,
-	}) as unknown as ReturnType<typeof getDatabase>;
+		first: vi.fn(),
+	}) as unknown as Knex;
 
-	return { db, first, where, update };
+	return { db, where, update };
 }
 
 describe('saveKey', () => {
@@ -23,44 +29,48 @@ describe('saveKey', () => {
 		vi.clearAllMocks();
 	});
 
-	test('updates directus_settings with license_key when project_id is provided', async () => {
+	test('encrypts and updates directus_settings with license_key when project_id is provided', async () => {
 		const { db, where, update } = createDbMock();
 		vi.mocked(getDatabase).mockReturnValue(db);
+		vi.mocked(getSecretUtils.getSecret).mockReturnValue('test-secret');
+		vi.mocked(encryptUtils.encrypt).mockResolvedValue('encrypted-license-key');
 
 		await saveKey('my-license-key', 'project-uuid');
 
-		expect(db.select).not.toHaveBeenCalled();
-		expect(db.from).not.toHaveBeenCalled();
-		expect(update).toHaveBeenCalledWith({ license_key: 'my-license-key' });
+		expect(getProjectIdUtils.getProjectId).not.toHaveBeenCalled();
+		expect(getSecretUtils.getSecret).toHaveBeenCalled();
+		expect(encryptUtils.encrypt).toHaveBeenCalledWith('my-license-key', 'test-secret');
+		expect(update).toHaveBeenCalledWith({ license_key: 'encrypted-license-key' });
 		expect(where).toHaveBeenCalledWith({ project_id: 'project-uuid' });
 	});
 
-	test('loads project_id from directus_settings when project_id is not provided', async () => {
-		const { db, first, where, update } = createDbMock();
-		first.mockResolvedValue({ project_id: 'resolved-id' });
+	test('uses getProjectId, encrypts and updates directus_settings when project_id is not provided', async () => {
+		const { db, where, update } = createDbMock();
 		vi.mocked(getDatabase).mockReturnValue(db);
+		vi.mocked(getProjectIdUtils.getProjectId).mockResolvedValue('resolved-id');
+		vi.mocked(getSecretUtils.getSecret).mockReturnValue('test-secret');
+		vi.mocked(encryptUtils.encrypt).mockResolvedValue('encrypted-license-key');
 
 		await saveKey('my-license-key');
 
-		expect(db.select).toHaveBeenCalledWith('project_id');
-		expect(db.from).toHaveBeenCalledWith('directus_settings');
-		expect(first).toHaveBeenCalledOnce();
-		expect(update).toHaveBeenCalledWith({ license_key: 'my-license-key' });
+		expect(getProjectIdUtils.getProjectId).toHaveBeenCalledOnce();
+		expect(encryptUtils.encrypt).toHaveBeenCalledWith('my-license-key', 'test-secret');
+		expect(update).toHaveBeenCalledWith({ license_key: 'encrypted-license-key' });
 		expect(where).toHaveBeenCalledWith({ project_id: 'resolved-id' });
 	});
 
-	test('throws when project_id is not provided and first row has no project_id', async () => {
-		const { db, first } = createDbMock();
-		first.mockResolvedValue({ project_id: null });
+	test('throws when project_id is not provided and getProjectId returns null', async () => {
+		const { db } = createDbMock();
 		vi.mocked(getDatabase).mockReturnValue(db);
+		vi.mocked(getProjectIdUtils.getProjectId).mockResolvedValue(undefined);
 
 		await expect(saveKey('my-license-key')).rejects.toThrow('project_id is missing or not a string');
 	});
 
-	test('throws when project_id is not provided and first row is undefined', async () => {
-		const { db, first } = createDbMock();
-		first.mockResolvedValue(undefined);
+	test('throws when project_id is not provided and getProjectId returns empty string', async () => {
+		const { db } = createDbMock();
 		vi.mocked(getDatabase).mockReturnValue(db);
+		vi.mocked(getProjectIdUtils.getProjectId).mockResolvedValue('');
 
 		await expect(saveKey('my-license-key')).rejects.toThrow('project_id is missing or not a string');
 	});

--- a/api/src/license/lib/save-key.test.ts
+++ b/api/src/license/lib/save-key.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { getDatabase } from '../../database/index.js';
+import { saveKey } from './save-key.js';
+
+vi.mock('../../database/index.js');
+
+function createDbMock() {
+	const first = vi.fn();
+	const where = vi.fn().mockResolvedValue(undefined);
+	const update = vi.fn().mockReturnValue({ where });
+
+	const db = Object.assign((_table: string) => ({ update }), {
+		select: vi.fn().mockReturnThis(),
+		from: vi.fn().mockReturnThis(),
+		first,
+	}) as unknown as ReturnType<typeof getDatabase>;
+
+	return { db, first, where, update };
+}
+
+describe('saveKey', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test('updates directus_settings with license_key when project_id is provided', async () => {
+		const { db, where, update } = createDbMock();
+		vi.mocked(getDatabase).mockReturnValue(db);
+
+		await saveKey('my-license-key', 'project-uuid');
+
+		expect(db.select).not.toHaveBeenCalled();
+		expect(db.from).not.toHaveBeenCalled();
+		expect(update).toHaveBeenCalledWith({ license_key: 'my-license-key' });
+		expect(where).toHaveBeenCalledWith({ project_id: 'project-uuid' });
+	});
+
+	test('loads project_id from directus_settings when project_id is not provided', async () => {
+		const { db, first, where, update } = createDbMock();
+		first.mockResolvedValue({ project_id: 'resolved-id' });
+		vi.mocked(getDatabase).mockReturnValue(db);
+
+		await saveKey('my-license-key');
+
+		expect(db.select).toHaveBeenCalledWith('project_id');
+		expect(db.from).toHaveBeenCalledWith('directus_settings');
+		expect(first).toHaveBeenCalledOnce();
+		expect(update).toHaveBeenCalledWith({ license_key: 'my-license-key' });
+		expect(where).toHaveBeenCalledWith({ project_id: 'resolved-id' });
+	});
+
+	test('throws when project_id is not provided and first row has no project_id', async () => {
+		const { db, first } = createDbMock();
+		first.mockResolvedValue({ project_id: null });
+		vi.mocked(getDatabase).mockReturnValue(db);
+
+		await expect(saveKey('my-license-key')).rejects.toThrow('project_id is missing or not a string');
+	});
+
+	test('throws when project_id is not provided and first row is undefined', async () => {
+		const { db, first } = createDbMock();
+		first.mockResolvedValue(undefined);
+		vi.mocked(getDatabase).mockReturnValue(db);
+
+		await expect(saveKey('my-license-key')).rejects.toThrow('project_id is missing or not a string');
+	});
+});

--- a/api/src/license/lib/save-key.ts
+++ b/api/src/license/lib/save-key.ts
@@ -1,0 +1,18 @@
+import { getDatabase } from '../../database/index.js';
+
+export async function saveKey(license_key: string, project_id?: string): Promise<void> {
+	const database = getDatabase();
+
+	if (!project_id) {
+		const settingsRow = await database.select('project_id').from('directus_settings').first();
+		const projectId = settingsRow?.project_id;
+
+		if (typeof projectId !== 'string' || !projectId) {
+			throw new Error('project_id is missing or not a string');
+		}
+
+		project_id = projectId;
+	}
+
+	await database('directus_settings').update({ license_key }).where({ project_id });
+}

--- a/api/src/license/lib/save-key.ts
+++ b/api/src/license/lib/save-key.ts
@@ -1,18 +1,18 @@
 import { getDatabase } from '../../database/index.js';
 
-export async function saveKey(license_key: string, project_id?: string): Promise<void> {
+export async function saveKey(licenseKey: string, projectId?: string): Promise<void> {
 	const database = getDatabase();
 
-	if (!project_id) {
+	if (!projectId) {
 		const settingsRow = await database.select('project_id').from('directus_settings').first();
-		const projectId = settingsRow?.project_id;
+		const storedProjectId = settingsRow?.project_id;
 
-		if (typeof projectId !== 'string' || !projectId) {
+		if (typeof storedProjectId !== 'string' || !storedProjectId) {
 			throw new Error('project_id is missing or not a string');
 		}
 
-		project_id = projectId;
+		projectId = storedProjectId;
 	}
 
-	await database('directus_settings').update({ license_key }).where({ project_id });
+	await database('directus_settings').update({ license_key: licenseKey }).where({ project_id: projectId });
 }

--- a/api/src/license/lib/save-key.ts
+++ b/api/src/license/lib/save-key.ts
@@ -1,11 +1,13 @@
 import { getDatabase } from '../../database/index.js';
+import { encrypt } from '../../utils/encrypt.js';
+import { getProjectId } from '../../utils/get-project-id.js';
+import { getSecret } from '../../utils/get-secret.js';
 
 export async function saveKey(licenseKey: string, projectId?: string): Promise<void> {
 	const database = getDatabase();
 
 	if (!projectId) {
-		const settingsRow = await database.select('project_id').from('directus_settings').first();
-		const storedProjectId = settingsRow?.project_id;
+		const storedProjectId = await getProjectId();
 
 		if (typeof storedProjectId !== 'string' || !storedProjectId) {
 			throw new Error('project_id is missing or not a string');
@@ -14,5 +16,8 @@ export async function saveKey(licenseKey: string, projectId?: string): Promise<v
 		projectId = storedProjectId;
 	}
 
-	await database('directus_settings').update({ license_key: licenseKey }).where({ project_id: projectId });
+	const secret = getSecret();
+	const encryptedKey = await encrypt(licenseKey, secret);
+
+	await database('directus_settings').update({ license_key: encryptedKey }).where({ project_id: projectId });
 }

--- a/api/src/license/lib/save-token.test.ts
+++ b/api/src/license/lib/save-token.test.ts
@@ -1,12 +1,17 @@
+import type { Knex } from 'knex';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { getDatabase } from '../../database/index.js';
 import * as cacheTokenPayload from '../../utils/cache-token-payload.js';
+import * as encryptUtils from '../../utils/encrypt.js';
+import * as getSecretUtils from '../../utils/get-secret.js';
 import { verify } from '../../utils/verify-token.js';
 import { saveToken } from './save-token.js';
 
 vi.mock('../../database/index.js');
 vi.mock('../../utils/verify-token.js');
 vi.mock('../../utils/cache-token-payload.js');
+vi.mock('../../utils/encrypt.js');
+vi.mock('../../utils/get-secret.js');
 
 function createDbMock() {
 	const first = vi.fn();
@@ -17,7 +22,7 @@ function createDbMock() {
 		select: vi.fn().mockReturnThis(),
 		from: vi.fn().mockReturnThis(),
 		first,
-	}) as unknown as ReturnType<typeof getDatabase>;
+	}) as unknown as Knex;
 
 	return { db, first, where, update };
 }
@@ -27,35 +32,43 @@ describe('saveToken', () => {
 		vi.clearAllMocks();
 	});
 
-	test('verifies token, updates directus_settings, and writes payload to cache when project_id is provided', async () => {
+	test('verifies token, encrypts it, updates directus_settings, and writes payload to cache when project_id is provided', async () => {
 		const { db, where, update } = createDbMock();
 		const payload = { plan: 'pro', metadata: {} };
 		vi.mocked(getDatabase).mockReturnValue(db);
+		vi.mocked(getSecretUtils.getSecret).mockReturnValue('test-secret');
+		vi.mocked(encryptUtils.encrypt).mockResolvedValue('encrypted-token');
 		vi.mocked(verify).mockResolvedValue(payload);
 
 		await saveToken('jwt-token', 'project-uuid');
 
 		expect(verify).toHaveBeenCalledWith('jwt-token');
+		expect(getSecretUtils.getSecret).toHaveBeenCalled();
+		expect(encryptUtils.encrypt).toHaveBeenCalledWith('jwt-token', 'test-secret');
 		expect(db.select).not.toHaveBeenCalled();
 		expect(db.from).not.toHaveBeenCalled();
-		expect(update).toHaveBeenCalledWith({ license_token: 'jwt-token' });
+		expect(update).toHaveBeenCalledWith({ license_token: 'encrypted-token' });
 		expect(where).toHaveBeenCalledWith({ project_id: 'project-uuid' });
 		expect(cacheTokenPayload.writeCacheTokenPayload).toHaveBeenCalledWith(payload);
 	});
 
-	test('loads project_id from directus_settings and writes payload to cache when project_id is not provided', async () => {
-		const { db, first, where } = createDbMock();
+	test('loads project_id from directus_settings, encrypts token, and writes payload to cache when project_id is not provided', async () => {
+		const { db, first, where, update } = createDbMock();
 		const payload = { plan: 'pro', metadata: {} };
 		first.mockResolvedValue({ project_id: 'resolved-id' });
 		vi.mocked(getDatabase).mockReturnValue(db);
+		vi.mocked(getSecretUtils.getSecret).mockReturnValue('test-secret');
+		vi.mocked(encryptUtils.encrypt).mockResolvedValue('encrypted-token');
 		vi.mocked(verify).mockResolvedValue(payload);
 
 		await saveToken('jwt-token');
 
 		expect(verify).toHaveBeenCalledWith('jwt-token');
+		expect(encryptUtils.encrypt).toHaveBeenCalledWith('jwt-token', 'test-secret');
 		expect(db.select).toHaveBeenCalledWith('project_id');
 		expect(db.from).toHaveBeenCalledWith('directus_settings');
 		expect(first).toHaveBeenCalledOnce();
+		expect(update).toHaveBeenCalledWith({ license_token: 'encrypted-token' });
 		expect(where).toHaveBeenCalledWith({ project_id: 'resolved-id' });
 		expect(cacheTokenPayload.writeCacheTokenPayload).toHaveBeenCalledWith(payload);
 	});

--- a/api/src/license/lib/save-token.test.ts
+++ b/api/src/license/lib/save-token.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { getDatabase } from '../../database/index.js';
+import { verify } from '../../utils/verify-token.js';
+import { saveToken } from './save-token.js';
+
+vi.mock('../../database/index.js');
+vi.mock('../../utils/verify-token.js');
+
+function createDbMock() {
+	const first = vi.fn();
+	const where = vi.fn().mockResolvedValue(undefined);
+	const update = vi.fn().mockReturnValue({ where });
+
+	const db = Object.assign((_table: string) => ({ update }), {
+		select: vi.fn().mockReturnThis(),
+		from: vi.fn().mockReturnThis(),
+		first,
+	}) as unknown as ReturnType<typeof getDatabase>;
+
+	return { db, first, where, update };
+}
+
+describe('saveToken', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test('verifies token then updates directus_settings when project_id is provided', async () => {
+		const { db, where, update } = createDbMock();
+		vi.mocked(getDatabase).mockReturnValue(db);
+		vi.mocked(verify).mockResolvedValue({});
+
+		await saveToken('jwt-token', 'project-uuid');
+
+		expect(verify).toHaveBeenCalledWith('jwt-token');
+		expect(db.select).not.toHaveBeenCalled();
+		expect(db.from).not.toHaveBeenCalled();
+		expect(update).toHaveBeenCalledWith({ license_token: 'jwt-token' });
+		expect(where).toHaveBeenCalledWith({ project_id: 'project-uuid' });
+	});
+
+	test('loads project_id from directus_settings when project_id is not provided', async () => {
+		const { db, first, where } = createDbMock();
+		first.mockResolvedValue({ project_id: 'resolved-id' });
+		vi.mocked(getDatabase).mockReturnValue(db);
+		vi.mocked(verify).mockResolvedValue({});
+
+		await saveToken('jwt-token');
+
+		expect(verify).toHaveBeenCalledWith('jwt-token');
+		expect(db.select).toHaveBeenCalledWith('project_id');
+		expect(db.from).toHaveBeenCalledWith('directus_settings');
+		expect(first).toHaveBeenCalledOnce();
+		expect(where).toHaveBeenCalledWith({ project_id: 'resolved-id' });
+	});
+
+	test('throws when verify throws', async () => {
+		const { db } = createDbMock();
+		vi.mocked(getDatabase).mockReturnValue(db);
+		vi.mocked(verify).mockRejectedValue(new Error('invalid token'));
+
+		await expect(saveToken('bad-token', 'project-uuid')).rejects.toThrow('invalid token');
+
+		expect(db).toBeDefined();
+	});
+
+	test('throws when project_id is not provided and first row has no project_id', async () => {
+		const { db, first } = createDbMock();
+		first.mockResolvedValue({ project_id: null });
+		vi.mocked(getDatabase).mockReturnValue(db);
+		vi.mocked(verify).mockResolvedValue({});
+
+		await expect(saveToken('jwt-token')).rejects.toThrow('project_id is missing or not a string');
+	});
+
+	test('throws when project_id is not provided and first row is undefined', async () => {
+		const { db, first } = createDbMock();
+		first.mockResolvedValue(undefined);
+		vi.mocked(getDatabase).mockReturnValue(db);
+		vi.mocked(verify).mockResolvedValue({});
+
+		await expect(saveToken('jwt-token')).rejects.toThrow('project_id is missing or not a string');
+	});
+});

--- a/api/src/license/lib/save-token.test.ts
+++ b/api/src/license/lib/save-token.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { getDatabase } from '../../database/index.js';
+import * as cacheTokenPayload from '../../utils/cache-token-payload.js';
 import { verify } from '../../utils/verify-token.js';
 import { saveToken } from './save-token.js';
 
 vi.mock('../../database/index.js');
 vi.mock('../../utils/verify-token.js');
+vi.mock('../../utils/cache-token-payload.js');
 
 function createDbMock() {
 	const first = vi.fn();
@@ -25,10 +27,11 @@ describe('saveToken', () => {
 		vi.clearAllMocks();
 	});
 
-	test('verifies token then updates directus_settings when project_id is provided', async () => {
+	test('verifies token, updates directus_settings, and writes payload to cache when project_id is provided', async () => {
 		const { db, where, update } = createDbMock();
+		const payload = { plan: 'pro', metadata: {} };
 		vi.mocked(getDatabase).mockReturnValue(db);
-		vi.mocked(verify).mockResolvedValue({});
+		vi.mocked(verify).mockResolvedValue(payload);
 
 		await saveToken('jwt-token', 'project-uuid');
 
@@ -37,13 +40,15 @@ describe('saveToken', () => {
 		expect(db.from).not.toHaveBeenCalled();
 		expect(update).toHaveBeenCalledWith({ license_token: 'jwt-token' });
 		expect(where).toHaveBeenCalledWith({ project_id: 'project-uuid' });
+		expect(cacheTokenPayload.writeCacheTokenPayload).toHaveBeenCalledWith(payload);
 	});
 
-	test('loads project_id from directus_settings when project_id is not provided', async () => {
+	test('loads project_id from directus_settings and writes payload to cache when project_id is not provided', async () => {
 		const { db, first, where } = createDbMock();
+		const payload = { plan: 'pro', metadata: {} };
 		first.mockResolvedValue({ project_id: 'resolved-id' });
 		vi.mocked(getDatabase).mockReturnValue(db);
-		vi.mocked(verify).mockResolvedValue({});
+		vi.mocked(verify).mockResolvedValue(payload);
 
 		await saveToken('jwt-token');
 
@@ -52,16 +57,17 @@ describe('saveToken', () => {
 		expect(db.from).toHaveBeenCalledWith('directus_settings');
 		expect(first).toHaveBeenCalledOnce();
 		expect(where).toHaveBeenCalledWith({ project_id: 'resolved-id' });
+		expect(cacheTokenPayload.writeCacheTokenPayload).toHaveBeenCalledWith(payload);
 	});
 
-	test('throws when verify throws', async () => {
+	test('throws when verify throws and does not call writeCacheTokenPayload', async () => {
 		const { db } = createDbMock();
 		vi.mocked(getDatabase).mockReturnValue(db);
 		vi.mocked(verify).mockRejectedValue(new Error('invalid token'));
 
 		await expect(saveToken('bad-token', 'project-uuid')).rejects.toThrow('invalid token');
 
-		expect(db).toBeDefined();
+		expect(cacheTokenPayload.writeCacheTokenPayload).not.toHaveBeenCalled();
 	});
 
 	test('throws when project_id is not provided and first row has no project_id', async () => {
@@ -71,6 +77,8 @@ describe('saveToken', () => {
 		vi.mocked(verify).mockResolvedValue({});
 
 		await expect(saveToken('jwt-token')).rejects.toThrow('project_id is missing or not a string');
+
+		expect(cacheTokenPayload.writeCacheTokenPayload).not.toHaveBeenCalled();
 	});
 
 	test('throws when project_id is not provided and first row is undefined', async () => {
@@ -80,5 +88,7 @@ describe('saveToken', () => {
 		vi.mocked(verify).mockResolvedValue({});
 
 		await expect(saveToken('jwt-token')).rejects.toThrow('project_id is missing or not a string');
+
+		expect(cacheTokenPayload.writeCacheTokenPayload).not.toHaveBeenCalled();
 	});
 });

--- a/api/src/license/lib/save-token.ts
+++ b/api/src/license/lib/save-token.ts
@@ -1,5 +1,8 @@
 import { getDatabase } from '../../database/index.js';
 import { writeCacheTokenPayload } from '../../utils/cache-token-payload.js';
+import { encrypt } from '../../utils/encrypt.js';
+import { getProjectId } from '../../utils/get-project-id.js';
+import { getSecret } from '../../utils/get-secret.js';
 import { verify } from '../../utils/verify-token.js';
 
 export async function saveToken(licenseToken: string, projectId?: string): Promise<void> {
@@ -8,8 +11,7 @@ export async function saveToken(licenseToken: string, projectId?: string): Promi
 	const database = getDatabase();
 
 	if (!projectId) {
-		const settingsRow = await database.select('project_id').from('directus_settings').first();
-		const storedProjectId = settingsRow?.project_id;
+		const storedProjectId = await getProjectId();
 
 		if (typeof storedProjectId !== 'string' || !storedProjectId) {
 			throw new Error('project_id is missing or not a string');
@@ -18,6 +20,9 @@ export async function saveToken(licenseToken: string, projectId?: string): Promi
 		projectId = storedProjectId;
 	}
 
-	await database('directus_settings').update({ license_token: licenseToken }).where({ project_id: projectId });
+	const secret = getSecret();
+	const encryptedToken = await encrypt(licenseToken, secret);
+
+	await database('directus_settings').update({ license_token: encryptedToken }).where({ project_id: projectId });
 	await writeCacheTokenPayload(payload);
 }

--- a/api/src/license/lib/save-token.ts
+++ b/api/src/license/lib/save-token.ts
@@ -1,0 +1,21 @@
+import { getDatabase } from '../../database/index.js';
+import { verify } from '../../utils/verify-token.js';
+
+export async function saveToken(license_token: string, project_id?: string): Promise<void> {
+	await verify(license_token);
+
+	const database = getDatabase();
+
+	if (!project_id) {
+		const settingsRow = await database.select('project_id').from('directus_settings').first();
+		const projectId = settingsRow?.project_id;
+
+		if (typeof projectId !== 'string' || !projectId) {
+			throw new Error('project_id is missing or not a string');
+		}
+
+		project_id = projectId;
+	}
+
+	await database('directus_settings').update({ license_token }).where({ project_id });
+}

--- a/api/src/license/lib/save-token.ts
+++ b/api/src/license/lib/save-token.ts
@@ -1,8 +1,9 @@
 import { getDatabase } from '../../database/index.js';
+import { writeCacheTokenPayload } from '../../utils/cache-token-payload.js';
 import { verify } from '../../utils/verify-token.js';
 
 export async function saveToken(license_token: string, project_id?: string): Promise<void> {
-	await verify(license_token);
+	const payload = await verify(license_token);
 
 	const database = getDatabase();
 
@@ -18,4 +19,5 @@ export async function saveToken(license_token: string, project_id?: string): Pro
 	}
 
 	await database('directus_settings').update({ license_token }).where({ project_id });
+	await writeCacheTokenPayload(payload);
 }

--- a/api/src/license/lib/save-token.ts
+++ b/api/src/license/lib/save-token.ts
@@ -2,22 +2,22 @@ import { getDatabase } from '../../database/index.js';
 import { writeCacheTokenPayload } from '../../utils/cache-token-payload.js';
 import { verify } from '../../utils/verify-token.js';
 
-export async function saveToken(license_token: string, project_id?: string): Promise<void> {
-	const payload = await verify(license_token);
+export async function saveToken(licenseToken: string, projectId?: string): Promise<void> {
+	const payload = await verify(licenseToken);
 
 	const database = getDatabase();
 
-	if (!project_id) {
+	if (!projectId) {
 		const settingsRow = await database.select('project_id').from('directus_settings').first();
-		const projectId = settingsRow?.project_id;
+		const storedProjectId = settingsRow?.project_id;
 
-		if (typeof projectId !== 'string' || !projectId) {
+		if (typeof storedProjectId !== 'string' || !storedProjectId) {
 			throw new Error('project_id is missing or not a string');
 		}
 
-		project_id = projectId;
+		projectId = storedProjectId;
 	}
 
-	await database('directus_settings').update({ license_token }).where({ project_id });
+	await database('directus_settings').update({ license_token: licenseToken }).where({ project_id: projectId });
 	await writeCacheTokenPayload(payload);
 }

--- a/api/src/license/lib/validate-and-save.test.ts
+++ b/api/src/license/lib/validate-and-save.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import * as setProjectIdModule from '../../utils/set-project-id.js';
+import * as saveKeyModule from './save-key.js';
+import * as saveTokenModule from './save-token.js';
+import { validateAndSave } from './validate-and-save.js';
+import * as validateModule from './validate.js';
+
+vi.mock('./validate.js');
+vi.mock('./save-key.js');
+vi.mock('./save-token.js');
+vi.mock('../../utils/set-project-id.js');
+
+describe('validateAndSave', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test('calls validate, saveToken, saveKey and setProjectId when validate returns projectId and storeKeyInDatabase is true', async () => {
+		vi.mocked(validateModule.validate).mockResolvedValue({
+			token: 'jwt-token',
+			projectId: 'new-project-id',
+		});
+
+		await validateAndSave('my-license-key', undefined, true);
+
+		expect(validateModule.validate).toHaveBeenCalledWith({ licenseKey: 'my-license-key' });
+		expect(saveTokenModule.saveToken).toHaveBeenCalledWith('jwt-token', undefined);
+		expect(saveKeyModule.saveKey).toHaveBeenCalledWith('my-license-key', undefined);
+		expect(setProjectIdModule.setProjectId).toHaveBeenCalledWith('new-project-id');
+	});
+
+	test('calls validate, saveToken and setProjectId but not saveKey when storeKeyInDatabase is false', async () => {
+		vi.mocked(validateModule.validate).mockResolvedValue({
+			token: 'jwt-token',
+			projectId: 'new-project-id',
+		});
+
+		await validateAndSave('my-license-key');
+
+		expect(validateModule.validate).toHaveBeenCalledWith({ licenseKey: 'my-license-key' });
+		expect(saveTokenModule.saveToken).toHaveBeenCalledWith('jwt-token', undefined);
+		expect(saveKeyModule.saveKey).not.toHaveBeenCalled();
+		expect(setProjectIdModule.setProjectId).toHaveBeenCalledWith('new-project-id');
+	});
+
+	test('does not call setProjectId when validate returns falsy projectId', async () => {
+		vi.mocked(validateModule.validate).mockResolvedValue({
+			token: 'jwt-token',
+			projectId: '',
+		});
+
+		await validateAndSave('my-license-key', undefined, true);
+
+		expect(saveTokenModule.saveToken).toHaveBeenCalledWith('jwt-token', undefined);
+		expect(saveKeyModule.saveKey).toHaveBeenCalledWith('my-license-key', undefined);
+		expect(setProjectIdModule.setProjectId).not.toHaveBeenCalled();
+	});
+
+	test('passes projectId to validate, saveToken and saveKey when provided', async () => {
+		vi.mocked(validateModule.validate).mockResolvedValue({
+			token: 'jwt-token',
+			projectId: 'returned-project-id',
+		});
+
+		await validateAndSave('my-license-key', 'existing-project-id', true);
+
+		expect(validateModule.validate).toHaveBeenCalledWith({
+			licenseKey: 'my-license-key',
+			projectId: 'existing-project-id',
+		});
+
+		expect(saveTokenModule.saveToken).toHaveBeenCalledWith('jwt-token', 'existing-project-id');
+		expect(saveKeyModule.saveKey).toHaveBeenCalledWith('my-license-key', 'existing-project-id');
+		expect(setProjectIdModule.setProjectId).toHaveBeenCalledWith('returned-project-id');
+	});
+
+	test('propagates error when validate throws', async () => {
+		vi.mocked(validateModule.validate).mockRejectedValue(new Error('invalid license'));
+
+		await expect(validateAndSave('bad-key', undefined, true)).rejects.toThrow('invalid license');
+
+		expect(saveTokenModule.saveToken).not.toHaveBeenCalled();
+		expect(saveKeyModule.saveKey).not.toHaveBeenCalled();
+		expect(setProjectIdModule.setProjectId).not.toHaveBeenCalled();
+	});
+});

--- a/api/src/license/lib/validate-and-save.ts
+++ b/api/src/license/lib/validate-and-save.ts
@@ -1,0 +1,22 @@
+import { setProjectId } from '../../utils/set-project-id.js';
+import { saveKey } from './save-key.js';
+import { saveToken } from './save-token.js';
+import { validate } from './validate.js';
+
+export async function validateAndSave(
+	licenseKey: string,
+	projectId?: string,
+	storeKeyInDatabase = false,
+): Promise<void> {
+	const { token, projectId: newProjectId } = await validate({ licenseKey, ...(projectId && { projectId }) });
+
+	await saveToken(token, projectId);
+
+	if (storeKeyInDatabase) {
+		await saveKey(licenseKey, projectId);
+	}
+
+	if (newProjectId) {
+		await setProjectId(newProjectId);
+	}
+}

--- a/api/src/license/lib/validate.test.ts
+++ b/api/src/license/lib/validate.test.ts
@@ -2,7 +2,7 @@ import { useEnv } from '@directus/env';
 import { InvalidLicenseConfigError, InvalidLicenseKeyError, ServiceUnavailableError } from '@directus/errors';
 import axios from 'axios';
 import { afterEach, expect, test, vi } from 'vitest';
-import { getDatabase } from '../../database/index.js';
+import * as getProjectIdUtils from '../../utils/get-project-id.js';
 import { validate } from './validate.js';
 
 vi.mock('@directus/env', () => ({
@@ -10,7 +10,7 @@ vi.mock('@directus/env', () => ({
 }));
 
 vi.mock('axios');
-vi.mock('../../database/index.js');
+vi.mock('../../utils/get-project-id.js');
 
 afterEach(() => {
 	vi.clearAllMocks();
@@ -20,7 +20,7 @@ test('validate throws InvalidLicenseConfigError when LICENSE_SERVER_URL is missi
 	vi.mocked(useEnv).mockReturnValue({});
 
 	await expect(
-		validate({ license_key: 'key', project_id: 'id', public_url: 'https://project.example.com' }),
+		validate({ licenseKey: 'key', projectId: 'id', publicUrl: 'https://project.example.com' }),
 	).rejects.toThrow('Missing or invalid license configuration. LICENSE_SERVER_URL is missing or not a string.');
 });
 
@@ -28,7 +28,7 @@ test('validate throws InvalidLicenseConfigError when LICENSE_SERVER_URL is not a
 	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 123 });
 
 	await expect(
-		validate({ license_key: 'key', project_id: 'id', public_url: 'https://project.example.com' }),
+		validate({ licenseKey: 'key', projectId: 'id', publicUrl: 'https://project.example.com' }),
 	).rejects.toThrow(InvalidLicenseConfigError);
 });
 
@@ -36,12 +36,12 @@ test('validate strips trailing slash from LICENSE_SERVER_URL', async () => {
 	const baseUrl = 'https://license.example.com/';
 	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: baseUrl });
 
-	vi.mocked(axios.post).mockResolvedValue({ data: { token: 't' } });
+	vi.mocked(axios.post).mockResolvedValue({ data: { token: 't', projectId: 'p' } });
 
 	await validate({
-		license_key: 'directus-license-key',
-		project_id: 'directus-project-id',
-		public_url: 'https://project.example.com',
+		licenseKey: 'directus-license-key',
+		projectId: 'directus-project-id',
+		publicUrl: 'https://project.example.com',
 	});
 
 	expect(axios.post).toHaveBeenCalledWith('https://license.example.com/v1/validate', {
@@ -54,12 +54,12 @@ test('validate strips trailing slash from LICENSE_SERVER_URL', async () => {
 test('validate POSTs to /v1/validate with request body using project_id from directus_settings', async () => {
 	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
 
-	vi.mocked(axios.post).mockResolvedValue({ data: { token: 'stored-token' } });
+	vi.mocked(axios.post).mockResolvedValue({ data: { token: 'stored-token', projectId: 'project-uuid' } });
 
 	await validate({
-		license_key: 'directus-license-key',
-		project_id: 'project-uuid',
-		public_url: 'https://project.example.com',
+		licenseKey: 'directus-license-key',
+		projectId: 'project-uuid',
+		publicUrl: 'https://project.example.com',
 	});
 
 	expect(axios.post).toHaveBeenCalledWith('https://license.example.com/v1/validate', {
@@ -69,18 +69,20 @@ test('validate POSTs to /v1/validate with request body using project_id from dir
 	});
 });
 
-test('validate returns license_token', async () => {
+test('validate returns token and projectId', async () => {
 	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
 
-	vi.mocked(axios.post).mockResolvedValue({ data: { token: 'jwt-token-from-service' } });
-
-	const result = await validate({
-		license_key: 'directus-license-key',
-		project_id: 'directus-project-id',
-		public_url: 'https://project.example.com',
+	vi.mocked(axios.post).mockResolvedValue({
+		data: { token: 'jwt-token-from-service', projectId: 'returned-project-id' },
 	});
 
-	expect(result).toEqual({ token: 'jwt-token-from-service' });
+	const result = await validate({
+		licenseKey: 'directus-license-key',
+		projectId: 'directus-project-id',
+		publicUrl: 'https://project.example.com',
+	});
+
+	expect(result).toEqual({ token: 'jwt-token-from-service', projectId: 'returned-project-id' });
 });
 
 test('validate rethrows non-Axios errors', async () => {
@@ -90,9 +92,9 @@ test('validate rethrows non-Axios errors', async () => {
 
 	await expect(
 		validate({
-			license_key: 'directus-license-key',
-			project_id: 'directus-project-id',
-			public_url: 'https://project.example.com',
+			licenseKey: 'directus-license-key',
+			projectId: 'directus-project-id',
+			publicUrl: 'https://project.example.com',
 		}),
 	).rejects.toThrow('Invalid license');
 });
@@ -109,9 +111,9 @@ test('validate throws InvalidLicenseKeyError for 403', async () => {
 	vi.mocked(axios.isAxiosError).mockReturnValue(true);
 
 	const err = await validate({
-		license_key: 'directus-license-key',
-		project_id: 'directus-project-id',
-		public_url: 'https://project.example.com',
+		licenseKey: 'directus-license-key',
+		projectId: 'directus-project-id',
+		publicUrl: 'https://project.example.com',
 	}).catch((e) => e);
 
 	expect(err).toBeInstanceOf(InvalidLicenseKeyError);
@@ -130,9 +132,9 @@ test('validate throws InvalidLicenseKeyError for 400', async () => {
 	vi.mocked(axios.isAxiosError).mockReturnValue(true);
 
 	const err = await validate({
-		license_key: 'directus-license-key',
-		project_id: 'directus-project-id',
-		public_url: 'https://project.example.com',
+		licenseKey: 'directus-license-key',
+		projectId: 'directus-project-id',
+		publicUrl: 'https://project.example.com',
 	}).catch((e) => e);
 
 	expect(err).toBeInstanceOf(InvalidLicenseKeyError);
@@ -151,9 +153,9 @@ test('validate throws ServiceUnavailableError for 429', async () => {
 	vi.mocked(axios.isAxiosError).mockReturnValue(true);
 
 	const err = await validate({
-		license_key: 'directus-license-key',
-		project_id: 'directus-project-id',
-		public_url: 'https://project.example.com',
+		licenseKey: 'directus-license-key',
+		projectId: 'directus-project-id',
+		publicUrl: 'https://project.example.com',
 	}).catch((e) => e);
 
 	expect(err).toBeInstanceOf(ServiceUnavailableError);
@@ -172,9 +174,9 @@ test('validate throws ServiceUnavailableError for 500 or network errors', async 
 	vi.mocked(axios.isAxiosError).mockReturnValue(true);
 
 	const err = await validate({
-		license_key: 'directus-license-key',
-		project_id: 'directus-project-id',
-		public_url: 'https://project.example.com',
+		licenseKey: 'directus-license-key',
+		projectId: 'directus-project-id',
+		publicUrl: 'https://project.example.com',
 	}).catch((e) => e);
 
 	expect(err).toBeInstanceOf(ServiceUnavailableError);
@@ -188,9 +190,9 @@ test('validate throws InvalidLicenseTokenError when response has no token', asyn
 
 	await expect(
 		validate({
-			license_key: 'directus-license-key',
-			project_id: 'directus-project-id',
-			public_url: 'https://project.example.com',
+			licenseKey: 'directus-license-key',
+			projectId: 'directus-project-id',
+			publicUrl: 'https://project.example.com',
 		}),
 	).rejects.toThrow('Missing or invalid license token.');
 });
@@ -202,36 +204,26 @@ test('validate throws InvalidLicenseTokenError when token is not a string', asyn
 
 	await expect(
 		validate({
-			license_key: 'directus-license-key',
-			project_id: 'directus-project-id',
-			public_url: 'https://project.example.com',
+			licenseKey: 'directus-license-key',
+			projectId: 'directus-project-id',
+			publicUrl: 'https://project.example.com',
 		}),
 	).rejects.toThrow('Missing or invalid license token.');
 });
 
-test('validate resolves project_id from database when not provided', async () => {
+test('validate resolves project_id via getProjectId when not provided', async () => {
 	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
 
-	const first = vi.fn().mockResolvedValue({ project_id: 'resolved-project-id' });
+	vi.mocked(getProjectIdUtils.getProjectId).mockResolvedValue('resolved-project-id');
 
-	const db = {
-		select: vi.fn().mockReturnThis(),
-		from: vi.fn().mockReturnThis(),
-		first,
-	} as unknown as ReturnType<typeof getDatabase>;
-
-	vi.mocked(getDatabase).mockReturnValue(db);
-
-	vi.mocked(axios.post).mockResolvedValue({ data: { token: 'jwt-token' } });
+	vi.mocked(axios.post).mockResolvedValue({ data: { token: 'jwt-token', projectId: 'resolved-project-id' } });
 
 	await validate({
-		license_key: 'directus-license-key',
-		public_url: 'https://project.example.com',
+		licenseKey: 'directus-license-key',
+		publicUrl: 'https://project.example.com',
 	});
 
-	expect(db.select).toHaveBeenCalledWith('project_id');
-	expect(db.from).toHaveBeenCalledWith('directus_settings');
-	expect(first).toHaveBeenCalled();
+	expect(getProjectIdUtils.getProjectId).toHaveBeenCalledOnce();
 
 	expect(axios.post).toHaveBeenCalledWith('https://license.example.com/v1/validate', {
 		license_key: 'directus-license-key',
@@ -240,23 +232,15 @@ test('validate resolves project_id from database when not provided', async () =>
 	});
 });
 
-test('validate throws InvalidLicenseConfigError when project_id cannot be resolved from database', async () => {
+test('validate throws InvalidLicenseConfigError when project_id cannot be resolved', async () => {
 	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
 
-	const first = vi.fn().mockResolvedValue({ project_id: null });
-
-	const db = {
-		select: vi.fn().mockReturnThis(),
-		from: vi.fn().mockReturnThis(),
-		first,
-	} as unknown as ReturnType<typeof getDatabase>;
-
-	vi.mocked(getDatabase).mockReturnValue(db);
+	vi.mocked(getProjectIdUtils.getProjectId).mockResolvedValue(undefined);
 
 	await expect(
 		validate({
-			license_key: 'directus-license-key',
-			public_url: 'https://project.example.com',
+			licenseKey: 'directus-license-key',
+			publicUrl: 'https://project.example.com',
 		}),
 	).rejects.toThrow(InvalidLicenseConfigError);
 });
@@ -267,11 +251,11 @@ test('validate resolves public_url from env when not provided', async () => {
 		PUBLIC_URL: 'https://env-project.example.com',
 	});
 
-	vi.mocked(axios.post).mockResolvedValue({ data: { token: 'jwt-token' } });
+	vi.mocked(axios.post).mockResolvedValue({ data: { token: 'jwt-token', projectId: 'directus-project-id' } });
 
 	await validate({
-		license_key: 'directus-license-key',
-		project_id: 'directus-project-id',
+		licenseKey: 'directus-license-key',
+		projectId: 'directus-project-id',
 	});
 
 	expect(axios.post).toHaveBeenCalledWith('https://license.example.com/v1/validate', {
@@ -288,8 +272,8 @@ test('validate throws InvalidLicenseConfigError when PUBLIC_URL cannot be resolv
 
 	await expect(
 		validate({
-			license_key: 'directus-license-key',
-			project_id: 'directus-project-id',
+			licenseKey: 'directus-license-key',
+			projectId: 'directus-project-id',
 		}),
 	).rejects.toThrow(InvalidLicenseConfigError);
 });

--- a/api/src/license/lib/validate.test.ts
+++ b/api/src/license/lib/validate.test.ts
@@ -2,6 +2,7 @@ import { useEnv } from '@directus/env';
 import { InvalidLicenseConfigError, InvalidLicenseKeyError, ServiceUnavailableError } from '@directus/errors';
 import axios from 'axios';
 import { afterEach, expect, test, vi } from 'vitest';
+import { getDatabase } from '../../database/index.js';
 import { validate } from './validate.js';
 
 vi.mock('@directus/env', () => ({
@@ -9,6 +10,7 @@ vi.mock('@directus/env', () => ({
 }));
 
 vi.mock('axios');
+vi.mock('../../database/index.js');
 
 afterEach(() => {
 	vi.clearAllMocks();
@@ -23,7 +25,7 @@ test('validate throws InvalidLicenseConfigError when LICENSE_SERVER_URL is missi
 });
 
 test('validate throws InvalidLicenseConfigError when LICENSE_SERVER_URL is not a string', async () => {
-	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 123 } as any);
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 123 });
 
 	await expect(
 		validate({ license_key: 'key', project_id: 'id', public_url: 'https://project.example.com' }),
@@ -32,9 +34,9 @@ test('validate throws InvalidLicenseConfigError when LICENSE_SERVER_URL is not a
 
 test('validate strips trailing slash from LICENSE_SERVER_URL', async () => {
 	const baseUrl = 'https://license.example.com/';
-	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: baseUrl } as any);
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: baseUrl });
 
-	vi.mocked(axios.post).mockResolvedValue({ data: { token: 't' } } as any);
+	vi.mocked(axios.post).mockResolvedValue({ data: { token: 't' } });
 
 	await validate({
 		license_key: 'directus-license-key',
@@ -50,9 +52,9 @@ test('validate strips trailing slash from LICENSE_SERVER_URL', async () => {
 });
 
 test('validate POSTs to /v1/validate with request body using project_id from directus_settings', async () => {
-	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' } as any);
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
 
-	vi.mocked(axios.post).mockResolvedValue({ data: { token: 'stored-token' } } as any);
+	vi.mocked(axios.post).mockResolvedValue({ data: { token: 'stored-token' } });
 
 	await validate({
 		license_key: 'directus-license-key',
@@ -68,9 +70,9 @@ test('validate POSTs to /v1/validate with request body using project_id from dir
 });
 
 test('validate returns license_token', async () => {
-	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' } as any);
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
 
-	vi.mocked(axios.post).mockResolvedValue({ data: { token: 'jwt-token-from-service' } } as any);
+	vi.mocked(axios.post).mockResolvedValue({ data: { token: 'jwt-token-from-service' } });
 
 	const result = await validate({
 		license_key: 'directus-license-key',
@@ -82,7 +84,7 @@ test('validate returns license_token', async () => {
 });
 
 test('validate rethrows non-Axios errors', async () => {
-	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' } as any);
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
 
 	vi.mocked(axios.post).mockRejectedValue(new Error('Invalid license'));
 
@@ -96,7 +98,7 @@ test('validate rethrows non-Axios errors', async () => {
 });
 
 test('validate throws InvalidLicenseKeyError for 403', async () => {
-	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' } as any);
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
 
 	const axiosError = Object.assign(new Error('Request failed with status code 403'), {
 		isAxiosError: true,
@@ -113,11 +115,11 @@ test('validate throws InvalidLicenseKeyError for 403', async () => {
 	}).catch((e) => e);
 
 	expect(err).toBeInstanceOf(InvalidLicenseKeyError);
-	expect((err as Error).message).toBe('Forbidden');
+	expect(err.message).toBe('Forbidden');
 });
 
 test('validate throws InvalidLicenseKeyError for 400', async () => {
-	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' } as any);
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
 
 	const axiosError = Object.assign(new Error('Request failed with status code 400'), {
 		isAxiosError: true,
@@ -134,11 +136,11 @@ test('validate throws InvalidLicenseKeyError for 400', async () => {
 	}).catch((e) => e);
 
 	expect(err).toBeInstanceOf(InvalidLicenseKeyError);
-	expect((err as Error).message).toBe('Bad Request');
+	expect(err.message).toBe('Bad Request');
 });
 
 test('validate throws ServiceUnavailableError for 429', async () => {
-	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' } as any);
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
 
 	const axiosError = Object.assign(new Error('Request failed with status code 429'), {
 		isAxiosError: true,
@@ -155,11 +157,11 @@ test('validate throws ServiceUnavailableError for 429', async () => {
 	}).catch((e) => e);
 
 	expect(err).toBeInstanceOf(ServiceUnavailableError);
-	expect((err as Error).message).toBe('Service "License Server" is unavailable. Too many requests.');
+	expect(err.message).toBe('Service "License Server" is unavailable. Too many requests.');
 });
 
 test('validate throws ServiceUnavailableError for 500 or network errors', async () => {
-	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' } as any);
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
 
 	const axiosError = Object.assign(new Error('Network error'), {
 		isAxiosError: true,
@@ -176,13 +178,13 @@ test('validate throws ServiceUnavailableError for 500 or network errors', async 
 	}).catch((e) => e);
 
 	expect(err).toBeInstanceOf(ServiceUnavailableError);
-	expect((err as Error).message).toBe('Service "License Server" is unavailable. Network error.');
+	expect(err.message).toBe('Service "License Server" is unavailable. Network error.');
 });
 
 test('validate throws InvalidLicenseTokenError when response has no token', async () => {
-	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' } as any);
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
 
-	vi.mocked(axios.post).mockResolvedValue({ data: {} } as any);
+	vi.mocked(axios.post).mockResolvedValue({ data: {} });
 
 	await expect(
 		validate({
@@ -194,9 +196,9 @@ test('validate throws InvalidLicenseTokenError when response has no token', asyn
 });
 
 test('validate throws InvalidLicenseTokenError when token is not a string', async () => {
-	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' } as any);
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
 
-	vi.mocked(axios.post).mockResolvedValue({ data: { token: 123 } } as any);
+	vi.mocked(axios.post).mockResolvedValue({ data: { token: 123 } });
 
 	await expect(
 		validate({
@@ -205,4 +207,89 @@ test('validate throws InvalidLicenseTokenError when token is not a string', asyn
 			public_url: 'https://project.example.com',
 		}),
 	).rejects.toThrow('Missing or invalid license token.');
+});
+
+test('validate resolves project_id from database when not provided', async () => {
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
+
+	const first = vi.fn().mockResolvedValue({ project_id: 'resolved-project-id' });
+
+	const db = {
+		select: vi.fn().mockReturnThis(),
+		from: vi.fn().mockReturnThis(),
+		first,
+	} as unknown as ReturnType<typeof getDatabase>;
+
+	vi.mocked(getDatabase).mockReturnValue(db);
+
+	vi.mocked(axios.post).mockResolvedValue({ data: { token: 'jwt-token' } });
+
+	await validate({
+		license_key: 'directus-license-key',
+		public_url: 'https://project.example.com',
+	});
+
+	expect(db.select).toHaveBeenCalledWith('project_id');
+	expect(db.from).toHaveBeenCalledWith('directus_settings');
+	expect(first).toHaveBeenCalled();
+
+	expect(axios.post).toHaveBeenCalledWith('https://license.example.com/v1/validate', {
+		license_key: 'directus-license-key',
+		project_id: 'resolved-project-id',
+		public_url: 'https://project.example.com',
+	});
+});
+
+test('validate throws InvalidLicenseConfigError when project_id cannot be resolved from database', async () => {
+	vi.mocked(useEnv).mockReturnValue({ LICENSE_SERVER_URL: 'https://license.example.com' });
+
+	const first = vi.fn().mockResolvedValue({ project_id: null });
+
+	const db = {
+		select: vi.fn().mockReturnThis(),
+		from: vi.fn().mockReturnThis(),
+		first,
+	} as unknown as ReturnType<typeof getDatabase>;
+
+	vi.mocked(getDatabase).mockReturnValue(db);
+
+	await expect(
+		validate({
+			license_key: 'directus-license-key',
+			public_url: 'https://project.example.com',
+		}),
+	).rejects.toThrow(InvalidLicenseConfigError);
+});
+
+test('validate resolves public_url from env when not provided', async () => {
+	vi.mocked(useEnv).mockReturnValue({
+		LICENSE_SERVER_URL: 'https://license.example.com',
+		PUBLIC_URL: 'https://env-project.example.com',
+	});
+
+	vi.mocked(axios.post).mockResolvedValue({ data: { token: 'jwt-token' } });
+
+	await validate({
+		license_key: 'directus-license-key',
+		project_id: 'directus-project-id',
+	});
+
+	expect(axios.post).toHaveBeenCalledWith('https://license.example.com/v1/validate', {
+		license_key: 'directus-license-key',
+		project_id: 'directus-project-id',
+		public_url: 'https://env-project.example.com',
+	});
+});
+
+test('validate throws InvalidLicenseConfigError when PUBLIC_URL cannot be resolved from env', async () => {
+	vi.mocked(useEnv).mockReturnValue({
+		LICENSE_SERVER_URL: 'https://license.example.com',
+	});
+
+	await expect(
+		validate({
+			license_key: 'directus-license-key',
+			project_id: 'directus-project-id',
+		}),
+	).rejects.toThrow(InvalidLicenseConfigError);
 });

--- a/api/src/license/lib/validate.ts
+++ b/api/src/license/lib/validate.ts
@@ -8,6 +8,7 @@ import {
 } from '@directus/errors';
 import type { AxiosError } from 'axios';
 import axios from 'axios';
+import { getDatabase } from '../../database/index.js';
 import type { ValidateLicenseRequest, ValidateLicenseResponse } from '../types/index.js';
 
 export async function validate({
@@ -20,6 +21,28 @@ export async function validate({
 
 	if (typeof url !== 'string' || !url) {
 		throw new InvalidLicenseConfigError({ reason: 'LICENSE_SERVER_URL is missing or not a string' });
+	}
+
+	if (!project_id) {
+		const database = getDatabase();
+		const settingsRow = await database.select('project_id').from('directus_settings').first();
+		const projectId = settingsRow?.project_id;
+
+		if (typeof projectId !== 'string' || !projectId) {
+			throw new InvalidLicenseConfigError({ reason: 'project_id is missing or not a string' });
+		}
+
+		project_id = projectId;
+	}
+
+	if (!public_url) {
+		const publicUrl = env['PUBLIC_URL'];
+
+		if (typeof publicUrl !== 'string' || !publicUrl) {
+			throw new InvalidLicenseConfigError({ reason: 'PUBLIC_URL is missing or not a string' });
+		}
+
+		public_url = publicUrl;
 	}
 
 	const baseUrl = url.replace(/\/$/, '');

--- a/api/src/license/types/deactivate.ts
+++ b/api/src/license/types/deactivate.ts
@@ -1,0 +1,8 @@
+export type DeactivateLicenseRequest = {
+	licenseKey: string;
+	projectId?: string;
+};
+
+export type DeactivateLicenseResponse = {
+	success: boolean;
+};

--- a/api/src/license/types/index.ts
+++ b/api/src/license/types/index.ts
@@ -1,1 +1,2 @@
 export * from './validate.js';
+export * from './deactivate.js';

--- a/api/src/license/types/validate.ts
+++ b/api/src/license/types/validate.ts
@@ -1,9 +1,10 @@
 export type ValidateLicenseRequest = {
-	license_key: string;
-	project_id?: string;
-	public_url?: string;
+	licenseKey: string;
+	projectId?: string;
+	publicUrl?: string;
 };
 
 export type ValidateLicenseResponse = {
 	token: string;
+	projectId: string;
 };

--- a/api/src/license/types/validate.ts
+++ b/api/src/license/types/validate.ts
@@ -1,7 +1,7 @@
 export type ValidateLicenseRequest = {
 	license_key: string;
 	project_id?: string;
-	public_url: string;
+	public_url?: string;
 };
 
 export type ValidateLicenseResponse = {

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -13,6 +13,7 @@ import qs from 'qs';
 import createApp from './app.js';
 import getDatabase from './database/index.js';
 import emitter from './emitter.js';
+import { getLicensePayload, validateAndSave } from './license/index.js';
 import { useLogger } from './logger/index.js';
 import { getAddress } from './utils/get-address.js';
 import { getConfigFromEnv } from './utils/get-config-from-env.js';
@@ -161,6 +162,23 @@ export async function createServer(): Promise<http.Server> {
 
 export async function startServer(): Promise<void> {
 	const server = await createServer();
+
+	const licenseKey = env['DIRECTUS_LICENSE_KEY'];
+	let licenseTokenPayload = null;
+
+	try {
+		licenseTokenPayload = await getLicensePayload();
+	} catch (err) {
+		logger.warn(err, 'License token payload could not be retrieved');
+	}
+
+	if (typeof licenseKey === 'string' && !licenseTokenPayload) {
+		try {
+			await validateAndSave(licenseKey);
+		} catch (err) {
+			logger.warn(err, 'License Key from DIRECTUS_LICENSE_KEY env could not be validated and saved');
+		}
+	}
 
 	const host = env['HOST'] as string;
 	const path = env['UNIX_SOCKET_PATH'] as string | undefined;

--- a/api/src/utils/cache-token-payload.test.ts
+++ b/api/src/utils/cache-token-payload.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import * as cache from '../cache.js';
+import { readCacheTokenPayload, writeCacheTokenPayload } from './cache-token-payload.js';
+
+vi.mock('../cache.js', () => ({
+	getCache: vi.fn(),
+	setCacheValue: vi.fn(),
+	getCacheValue: vi.fn(),
+}));
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+describe('cache-token-payload utilities', () => {
+	test('writeCacheTokenPayload writes payload to system cache with fixed key', async () => {
+		const mockSystemCache = {};
+		vi.mocked(cache.getCache).mockReturnValue({ systemCache: mockSystemCache } as any);
+
+		const payload = { plan: 'pro', seats: 10 };
+
+		await writeCacheTokenPayload(payload);
+
+		expect(cache.getCache).toHaveBeenCalled();
+		expect(cache.setCacheValue).toHaveBeenCalledWith(mockSystemCache, 'licenseTokenPayload', payload);
+	});
+
+	test('readCacheTokenPayload reads payload from system cache with fixed key', async () => {
+		const mockSystemCache = {};
+		const cachedPayload = { plan: 'free' };
+
+		vi.mocked(cache.getCache).mockReturnValue({ systemCache: mockSystemCache } as any);
+		vi.mocked(cache.getCacheValue).mockResolvedValue(cachedPayload);
+
+		const result = await readCacheTokenPayload();
+
+		expect(cache.getCache).toHaveBeenCalled();
+		expect(cache.getCacheValue).toHaveBeenCalledWith(mockSystemCache, 'licenseTokenPayload');
+		expect(result).toEqual(cachedPayload);
+	});
+});

--- a/api/src/utils/cache-token-payload.test.ts
+++ b/api/src/utils/cache-token-payload.test.ts
@@ -15,7 +15,7 @@ afterEach(() => {
 describe('cache-token-payload utilities', () => {
 	test('writeCacheTokenPayload writes payload to system cache with fixed key', async () => {
 		const mockSystemCache = {};
-		vi.mocked(cache.getCache).mockReturnValue({ systemCache: mockSystemCache } as any);
+		vi.mocked(cache.getCache).mockReturnValue({ systemCache: mockSystemCache } as ReturnType<typeof cache.getCache>);
 
 		const payload = { plan: 'pro', seats: 10 };
 
@@ -29,7 +29,7 @@ describe('cache-token-payload utilities', () => {
 		const mockSystemCache = {};
 		const cachedPayload = { plan: 'free' };
 
-		vi.mocked(cache.getCache).mockReturnValue({ systemCache: mockSystemCache } as any);
+		vi.mocked(cache.getCache).mockReturnValue({ systemCache: mockSystemCache } as ReturnType<typeof cache.getCache>);
 		vi.mocked(cache.getCacheValue).mockResolvedValue(cachedPayload);
 
 		const result = await readCacheTokenPayload();

--- a/api/src/utils/cache-token-payload.test.ts
+++ b/api/src/utils/cache-token-payload.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import * as cache from '../cache.js';
-import { readCacheTokenPayload, writeCacheTokenPayload } from './cache-token-payload.js';
+import { deleteCacheTokenPayload, readCacheTokenPayload, writeCacheTokenPayload } from './cache-token-payload.js';
 
 vi.mock('../cache.js', () => ({
 	getCache: vi.fn(),
@@ -37,5 +37,19 @@ describe('cache-token-payload utilities', () => {
 		expect(cache.getCache).toHaveBeenCalledOnce();
 		expect(cache.getCacheValue).toHaveBeenCalledWith(mockSystemCache, 'licenseTokenPayload');
 		expect(result).toEqual(cachedPayload);
+	});
+
+	test('deleteCacheTokenPayload deletes payload from system cache with fixed key', async () => {
+		const deleteMock = vi.fn().mockResolvedValue(undefined);
+		const mockSystemCache = { delete: deleteMock };
+
+		vi.mocked(cache.getCache).mockReturnValue({
+			systemCache: mockSystemCache,
+		} as unknown as ReturnType<typeof cache.getCache>);
+
+		await deleteCacheTokenPayload();
+
+		expect(cache.getCache).toHaveBeenCalledOnce();
+		expect(deleteMock).toHaveBeenCalledWith('licenseTokenPayload');
 	});
 });

--- a/api/src/utils/cache-token-payload.test.ts
+++ b/api/src/utils/cache-token-payload.test.ts
@@ -21,7 +21,7 @@ describe('cache-token-payload utilities', () => {
 
 		await writeCacheTokenPayload(payload);
 
-		expect(cache.getCache).toHaveBeenCalled();
+		expect(cache.getCache).toHaveBeenCalledOnce();
 		expect(cache.setCacheValue).toHaveBeenCalledWith(mockSystemCache, 'licenseTokenPayload', payload);
 	});
 
@@ -34,7 +34,7 @@ describe('cache-token-payload utilities', () => {
 
 		const result = await readCacheTokenPayload();
 
-		expect(cache.getCache).toHaveBeenCalled();
+		expect(cache.getCache).toHaveBeenCalledOnce();
 		expect(cache.getCacheValue).toHaveBeenCalledWith(mockSystemCache, 'licenseTokenPayload');
 		expect(result).toEqual(cachedPayload);
 	});

--- a/api/src/utils/cache-token-payload.ts
+++ b/api/src/utils/cache-token-payload.ts
@@ -1,0 +1,13 @@
+import { getCache, getCacheValue, setCacheValue } from '../cache.js';
+
+const CACHE_KEY = 'licenseTokenPayload';
+
+export async function writeCacheTokenPayload(payload: Record<string, any>) {
+	const { systemCache } = getCache();
+	await setCacheValue(systemCache, CACHE_KEY, payload as Record<string, any>);
+}
+
+export async function readCacheTokenPayload() {
+	const { systemCache } = getCache();
+	return await getCacheValue(systemCache, CACHE_KEY);
+}

--- a/api/src/utils/cache-token-payload.ts
+++ b/api/src/utils/cache-token-payload.ts
@@ -2,12 +2,12 @@ import { getCache, getCacheValue, setCacheValue } from '../cache.js';
 
 const CACHE_KEY = 'licenseTokenPayload';
 
-export async function writeCacheTokenPayload(payload: Record<string, any>) {
+export async function writeCacheTokenPayload(payload: Record<string, unknown>) {
 	const { systemCache } = getCache();
-	await setCacheValue(systemCache, CACHE_KEY, payload as Record<string, any>);
+	await setCacheValue(systemCache, CACHE_KEY, payload);
 }
 
-export async function readCacheTokenPayload() {
+export async function readCacheTokenPayload(): Promise<Record<string, unknown> | undefined> {
 	const { systemCache } = getCache();
 	return await getCacheValue(systemCache, CACHE_KEY);
 }

--- a/api/src/utils/cache-token-payload.ts
+++ b/api/src/utils/cache-token-payload.ts
@@ -11,3 +11,8 @@ export async function readCacheTokenPayload(): Promise<Record<string, unknown> |
 	const { systemCache } = getCache();
 	return await getCacheValue(systemCache, CACHE_KEY);
 }
+
+export async function deleteCacheTokenPayload() {
+	const { systemCache } = getCache();
+	await systemCache.delete(CACHE_KEY);
+}

--- a/api/src/utils/get-project-id.test.ts
+++ b/api/src/utils/get-project-id.test.ts
@@ -1,0 +1,58 @@
+import type { Knex } from 'knex';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { getDatabase } from '../database/index.js';
+import { getProjectId } from './get-project-id.js';
+
+vi.mock('../database/index.js');
+
+function createDbMock() {
+	const first = vi.fn();
+
+	const db = Object.assign(vi.fn(), {
+		select: vi.fn().mockReturnThis(),
+		from: vi.fn().mockReturnThis(),
+		first,
+	}) as unknown as Knex;
+
+	return { db, first };
+}
+
+describe('getProjectId', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test('returns project_id from first row of directus_settings', async () => {
+		const { db, first } = createDbMock();
+		first.mockResolvedValue({ project_id: 'my-project-uuid' });
+		vi.mocked(getDatabase).mockReturnValue(db);
+
+		const result = await getProjectId();
+
+		expect(getDatabase).toHaveBeenCalledOnce();
+		expect(db.select).toHaveBeenCalledWith('project_id');
+		expect(db.from).toHaveBeenCalledWith('directus_settings');
+		expect(first).toHaveBeenCalledOnce();
+		expect(result).toBe('my-project-uuid');
+	});
+
+	test('returns undefined when first row has no project_id', async () => {
+		const { db, first } = createDbMock();
+		first.mockResolvedValue({ project_id: null });
+		vi.mocked(getDatabase).mockReturnValue(db);
+
+		const result = await getProjectId();
+
+		expect(result).toBeUndefined();
+	});
+
+	test('returns undefined when no row exists', async () => {
+		const { db, first } = createDbMock();
+		first.mockResolvedValue(undefined);
+		vi.mocked(getDatabase).mockReturnValue(db);
+
+		const result = await getProjectId();
+
+		expect(result).toBeUndefined();
+	});
+});

--- a/api/src/utils/get-project-id.ts
+++ b/api/src/utils/get-project-id.ts
@@ -4,5 +4,10 @@ export async function getProjectId(): Promise<string | undefined> {
 	const database = getDatabase();
 	const settingsRow = await database.select('project_id').from('directus_settings').first();
 	const projectId = settingsRow?.project_id;
+
+	if (!projectId) {
+		return undefined;
+	}
+
 	return projectId;
 }

--- a/api/src/utils/get-project-id.ts
+++ b/api/src/utils/get-project-id.ts
@@ -1,0 +1,8 @@
+import { getDatabase } from '../database/index.js';
+
+export async function getProjectId(): Promise<string | undefined> {
+	const database = getDatabase();
+	const settingsRow = await database.select('project_id').from('directus_settings').first();
+	const projectId = settingsRow?.project_id;
+	return projectId;
+}

--- a/api/src/utils/set-project-id.test.ts
+++ b/api/src/utils/set-project-id.test.ts
@@ -1,0 +1,73 @@
+import type { Knex } from 'knex';
+import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
+import { getDatabase } from '../database/index.js';
+import * as loggerModule from '../logger/index.js';
+import { setProjectId } from './set-project-id.js';
+
+vi.mock('../database/index.js');
+
+vi.mock('../logger/index.js', () => ({
+	useLogger: vi.fn().mockReturnValue({ warn: vi.fn() }),
+}));
+
+let loggerRef: { warn: ReturnType<typeof vi.fn> };
+
+function createDbMock() {
+	const first = vi.fn();
+	const where = vi.fn().mockResolvedValue(undefined);
+	const update = vi.fn().mockReturnValue({ where });
+
+	const db = Object.assign(vi.fn().mockReturnValue({ update }), {
+		select: vi.fn().mockReturnThis(),
+		from: vi.fn().mockReturnThis(),
+		first,
+	}) as unknown as Knex;
+
+	return { db, first, where, update };
+}
+
+describe('setProjectId', () => {
+	beforeAll(() => {
+		loggerRef = vi.mocked(loggerModule.useLogger).mock.results[0]!.value as { warn: ReturnType<typeof vi.fn> };
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test('updates project_id on first row of directus_settings', async () => {
+		const { db, first, where, update } = createDbMock();
+		first.mockResolvedValue({ id: 'settings-row-id' });
+		vi.mocked(getDatabase).mockReturnValue(db);
+
+		await setProjectId('new-project-uuid');
+
+		expect(getDatabase).toHaveBeenCalledOnce();
+		expect(db.select).toHaveBeenCalledWith('id');
+		expect(db.from).toHaveBeenCalledWith('directus_settings');
+		expect(first).toHaveBeenCalledOnce();
+		expect(db).toHaveBeenCalledWith('directus_settings');
+		expect(update).toHaveBeenCalledWith({ project_id: 'new-project-uuid' });
+		expect(where).toHaveBeenCalledWith('id', 'settings-row-id');
+	});
+
+	test('logs and throws when directus_settings has no row', async () => {
+		const { db, first } = createDbMock();
+		first.mockResolvedValue(undefined);
+		vi.mocked(getDatabase).mockReturnValue(db);
+
+		await expect(setProjectId('new-project-uuid')).rejects.toThrow('Failed to set project_id');
+
+		expect(loggerRef.warn).toHaveBeenCalledWith('Failed to set project_id: table directus_settings has no row');
+	});
+
+	test('throws when first row has no id', async () => {
+		const { db, first } = createDbMock();
+		first.mockResolvedValue({ id: null });
+		vi.mocked(getDatabase).mockReturnValue(db);
+
+		await expect(setProjectId('new-project-uuid')).rejects.toThrow('Failed to set project_id');
+
+		expect(loggerRef.warn).toHaveBeenCalledWith('Failed to set project_id: table directus_settings has no row');
+	});
+});

--- a/api/src/utils/set-project-id.ts
+++ b/api/src/utils/set-project-id.ts
@@ -1,0 +1,16 @@
+import { getDatabase } from '../database/index.js';
+import { useLogger } from '../logger/index.js';
+
+const logger = useLogger();
+
+export async function setProjectId(projectId: string): Promise<void> {
+	const database = getDatabase();
+	const row = await database.select('id').from('directus_settings').first();
+
+	if (!row?.id) {
+		logger.warn('Failed to set project_id: table directus_settings has no row');
+		throw new Error('Failed to set project_id');
+	}
+
+	await database('directus_settings').update({ project_id: projectId }).where('id', row.id);
+}


### PR DESCRIPTION
## Scope

What's changed:
- Default getting public_url from ENV when validate license key
- Default getting project_id from directus_settings table when validate license key
- Update unit test to remove cast type 
- Add utils to store token and key into database
- Add util to delete cached license payload 
- Add util to deactivate license key 
- Add util to update the project_id if validate call to licensing service return one
- Add feature to deactivate/activate license key from settings page 

## Potential Risks / Drawbacks
- N/A

## Tested Scenarios
- N/A

## Review Notes / Questions
- N/A

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #\<num\>
