### PR TITLE
DIR-9: validate license key from ENV when server startup

### DIFF
--- a/api/src/license/index.ts
+++ b/api/src/license/index.ts
@@ -4,3 +4,4 @@ export * from './lib/get-key.js';
 export * from './lib/get-license-payload.js';
 export * from './lib/save-key.js';
 export * from './lib/save-token.js';
+export * from './lib/validate-and-save.js';

--- a/api/src/license/lib/validate-and-save.test.ts
+++ b/api/src/license/lib/validate-and-save.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import * as setProjectIdModule from '../../utils/set-project-id.js';
+import * as saveKeyModule from './save-key.js';
+import * as saveTokenModule from './save-token.js';
+import { validateAndSave } from './validate-and-save.js';
+import * as validateModule from './validate.js';
+
+vi.mock('./validate.js');
+vi.mock('./save-key.js');
+vi.mock('./save-token.js');
+vi.mock('../../utils/set-project-id.js');
+
+describe('validateAndSave', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test('calls validate, saveToken, saveKey and setProjectId when validate returns projectId and storeKeyInDatabase is true', async () => {
+		vi.mocked(validateModule.validate).mockResolvedValue({
+			token: 'jwt-token',
+			projectId: 'new-project-id',
+		});
+
+		await validateAndSave('my-license-key', undefined, true);
+
+		expect(validateModule.validate).toHaveBeenCalledWith({ licenseKey: 'my-license-key' });
+		expect(saveTokenModule.saveToken).toHaveBeenCalledWith('jwt-token', undefined);
+		expect(saveKeyModule.saveKey).toHaveBeenCalledWith('my-license-key', undefined);
+		expect(setProjectIdModule.setProjectId).toHaveBeenCalledWith('new-project-id');
+	});
+
+	test('calls validate, saveToken and setProjectId but not saveKey when storeKeyInDatabase is false', async () => {
+		vi.mocked(validateModule.validate).mockResolvedValue({
+			token: 'jwt-token',
+			projectId: 'new-project-id',
+		});
+
+		await validateAndSave('my-license-key');
+
+		expect(validateModule.validate).toHaveBeenCalledWith({ licenseKey: 'my-license-key' });
+		expect(saveTokenModule.saveToken).toHaveBeenCalledWith('jwt-token', undefined);
+		expect(saveKeyModule.saveKey).not.toHaveBeenCalled();
+		expect(setProjectIdModule.setProjectId).toHaveBeenCalledWith('new-project-id');
+	});
+
+	test('does not call setProjectId when validate returns falsy projectId', async () => {
+		vi.mocked(validateModule.validate).mockResolvedValue({
+			token: 'jwt-token',
+			projectId: '',
+		});
+
+		await validateAndSave('my-license-key', undefined, true);
+
+		expect(saveTokenModule.saveToken).toHaveBeenCalledWith('jwt-token', undefined);
+		expect(saveKeyModule.saveKey).toHaveBeenCalledWith('my-license-key', undefined);
+		expect(setProjectIdModule.setProjectId).not.toHaveBeenCalled();
+	});
+
+	test('passes projectId to validate, saveToken and saveKey when provided', async () => {
+		vi.mocked(validateModule.validate).mockResolvedValue({
+			token: 'jwt-token',
+			projectId: 'returned-project-id',
+		});
+
+		await validateAndSave('my-license-key', 'existing-project-id', true);
+
+		expect(validateModule.validate).toHaveBeenCalledWith({
+			licenseKey: 'my-license-key',
+			projectId: 'existing-project-id',
+		});
+
+		expect(saveTokenModule.saveToken).toHaveBeenCalledWith('jwt-token', 'existing-project-id');
+		expect(saveKeyModule.saveKey).toHaveBeenCalledWith('my-license-key', 'existing-project-id');
+		expect(setProjectIdModule.setProjectId).toHaveBeenCalledWith('returned-project-id');
+	});
+
+	test('propagates error when validate throws', async () => {
+		vi.mocked(validateModule.validate).mockRejectedValue(new Error('invalid license'));
+
+		await expect(validateAndSave('bad-key', undefined, true)).rejects.toThrow('invalid license');
+
+		expect(saveTokenModule.saveToken).not.toHaveBeenCalled();
+		expect(saveKeyModule.saveKey).not.toHaveBeenCalled();
+		expect(setProjectIdModule.setProjectId).not.toHaveBeenCalled();
+	});
+});

--- a/api/src/license/lib/validate-and-save.ts
+++ b/api/src/license/lib/validate-and-save.ts
@@ -1,0 +1,22 @@
+import { setProjectId } from '../../utils/set-project-id.js';
+import { saveKey } from './save-key.js';
+import { saveToken } from './save-token.js';
+import { validate } from './validate.js';
+
+export async function validateAndSave(
+	licenseKey: string,
+	projectId?: string,
+	storeKeyInDatabase = false,
+): Promise<void> {
+	const { token, projectId: newProjectId } = await validate({ licenseKey, ...(projectId && { projectId }) });
+
+	await saveToken(token, projectId);
+
+	if (storeKeyInDatabase) {
+		await saveKey(licenseKey, projectId);
+	}
+
+	if (newProjectId) {
+		await setProjectId(newProjectId);
+	}
+}

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -13,6 +13,7 @@ import qs from 'qs';
 import createApp from './app.js';
 import getDatabase from './database/index.js';
 import emitter from './emitter.js';
+import { getLicensePayload, validateAndSave } from './license/index.js';
 import { useLogger } from './logger/index.js';
 import { getAddress } from './utils/get-address.js';
 import { getConfigFromEnv } from './utils/get-config-from-env.js';
@@ -161,6 +162,23 @@ export async function createServer(): Promise<http.Server> {
 
 export async function startServer(): Promise<void> {
 	const server = await createServer();
+
+	const licenseKey = env['DIRECTUS_LICENSE_KEY'];
+	let licenseTokenPayload = null;
+
+	try {
+		licenseTokenPayload = await getLicensePayload();
+	} catch (err) {
+		logger.warn(err, 'License token payload could not be retrieved');
+	}
+
+	if (typeof licenseKey === 'string' && !licenseTokenPayload) {
+		try {
+			await validateAndSave(licenseKey);
+		} catch (err) {
+			logger.warn(err, 'License Key from DIRECTUS_LICENSE_KEY env could not be validated and saved');
+		}
+	}
 
 	const host = env['HOST'] as string;
 	const path = env['UNIX_SOCKET_PATH'] as string | undefined;


### PR DESCRIPTION
## Scope

What's changed:
- Add util `validateAndSave` to validate license key, store token in db, store key in db (optional) and cache the license payload
- In server startup, check if valid token is presented, if not call `validateAndSave` util to validate license key and store necessary data

## Potential Risks / Drawbacks
- N/A

## Tested Scenarios
- N/A

## Review Notes / Questions
- N/A

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #\<num\>
