### PR TITLE
feat(license): Plan Usage custom labels and Add-on Packages improvements (DIR-69, DIR-70, DIR-71)

### DIFF
--- a/api/src/license/addons.ts
+++ b/api/src/license/addons.ts
@@ -9,6 +9,8 @@ export interface LicenseAddon {
 	description: string;
 	status: 'available' | 'purchased';
 	action: 'purchase' | 'info';
+	icon?: string;
+	disabled?: boolean;
 }
 
 export interface LicenseAddonsResponse {
@@ -23,18 +25,40 @@ export async function getLicenseAddons(): Promise<LicenseAddonsResponse> {
 	return {
 		addons: [
 			{
+				id: 'user_seats',
+				name: 'User Seats',
+				description: '$15.00 per seat',
+				status: 'available',
+				action: 'purchase',
+				icon: 'group',
+				disabled: false,
+			},
+			{
 				id: 'sso',
 				name: 'SSO Feature',
 				description: 'Allows SSO configuration',
 				status: 'available',
 				action: 'purchase',
+				icon: 'cloud_lock',
+				disabled: false,
 			},
 			{
-				id: 'user_seats',
-				name: 'User Seats',
-				description: 'Additional +1 user seat',
+				id: 'collections',
+				name: 'Data Model Collections',
+				description: 'Additional collections',
 				status: 'available',
 				action: 'purchase',
+				icon: 'inventory_2',
+				disabled: true,
+			},
+			{
+				id: 'basic_support',
+				name: 'Basic Support',
+				description: '',
+				status: 'available',
+				action: 'purchase',
+				icon: 'support_agent',
+				disabled: true,
 			},
 		],
 	};

--- a/app/src/interfaces/presentation-license-section/presentation-license-section.vue
+++ b/app/src/interfaces/presentation-license-section/presentation-license-section.vue
@@ -52,6 +52,9 @@ const onConfirmDeactivate = inject<() => void>('license:onConfirmDeactivate', ()
 			:custom-rules-available="value.customRulesAvailable ?? false"
 			:custom-llm-available="value.customLlmAvailable ?? false"
 			:sso-available="value.ssoAvailable ?? false"
+			:label-included="value.labelIncluded"
+			:label-not-included="value.labelNotIncluded"
+			:label-optional="value.labelOptional"
 		/>
 		<LicenseAddonsSection
 			v-else-if="section === 'addons' && value"

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -65,10 +65,10 @@ settings_license_your_plan_usage: Your Plan Usage
 settings_license_add_on_packages: Add-on Packages
 settings_license_add_on_info: Learn more about this add-on
 settings_license_purchase: Purchase
-settings_license_usage_available: Enabled
-settings_license_usage_unavailable: Disabled
+settings_license_usage_available: Included
+settings_license_usage_unavailable: Not Included
 settings_license_usage_disabled: Disabled
-settings_license_usage_opt_in: Opt-in
+settings_license_usage_opt_in: Optional
 settings_license_usage_collections: Collections
 settings_license_usage_seats: Seats
 settings_license_usage_sso: SSO

--- a/app/src/modules/settings/routes/license/components/license-addons-section.vue
+++ b/app/src/modules/settings/routes/license/components/license-addons-section.vue
@@ -13,6 +13,8 @@ type Addon = {
 	icon: string;
 	showPurchase: boolean;
 	showInfo: boolean;
+	disabled?: boolean;
+	showUpgradePlan?: boolean;
 };
 
 defineProps<{
@@ -38,13 +40,21 @@ defineProps<{
 				{{ addonsError }}
 			</VNotice>
 			<template v-else>
-				<div v-for="pkg in addons" :key="pkg.id" class="add-on-card">
-					<div class="add-on-icon-wrapper">
+				<div v-for="pkg in addons" :key="pkg.id" class="add-on-card" :class="{ 'add-on-card--disabled': pkg.disabled }">
+					<div class="add-on-icon-wrapper" :class="{ 'add-on-icon-wrapper--disabled': pkg.disabled }">
 						<VIcon :name="pkg.icon" class="add-on-icon" />
 					</div>
 					<div class="add-on-content">
-						<span class="add-on-title">{{ pkg.name }}</span>
-						<span class="add-on-description">{{ pkg.description }}</span>
+						<span class="add-on-title" :class="{ 'add-on-title--disabled': pkg.disabled }">
+							{{ pkg.name }}
+						</span>
+						<span
+							v-if="pkg.description"
+							class="add-on-description"
+							:class="{ 'add-on-description--disabled': pkg.disabled }"
+						>
+							{{ pkg.description }}
+						</span>
 					</div>
 					<VButton
 						v-if="pkg.showPurchase"
@@ -54,7 +64,19 @@ defineProps<{
 						:href="`https://directus.io/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2025_10_kyc&utm_term=${version}&utm_content=settings_addon_${pkg.id}`"
 						target="_blank"
 					>
+						<VIcon name="add_shopping_cart" class="add-on-purchase-icon" />
 						{{ $t('settings_license_purchase') }}
+					</VButton>
+					<VButton
+						v-else-if="pkg.showUpgradePlan"
+						secondary
+						small
+						class="add-on-upgrade-btn"
+						:href="`https://directus.io/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2025_10_kyc&utm_term=${version}&utm_content=settings_addon_upgrade_${pkg.id}`"
+						target="_blank"
+					>
+						<VIcon name="diamond" class="add-on-upgrade-icon" />
+						{{ $t('settings_license_upgrade_plan') }}
 					</VButton>
 					<VIcon
 						v-else-if="pkg.showInfo"
@@ -126,6 +148,14 @@ defineProps<{
 	flex-shrink: 0;
 }
 
+.add-on-icon-wrapper--disabled {
+	background: var(--theme--background-normal);
+}
+
+.add-on-icon-wrapper--disabled .add-on-icon {
+	--v-icon-color: var(--theme--foreground-subdued);
+}
+
 .add-on-icon {
 	--v-icon-color: var(--white);
 	--v-icon-size: 22px;
@@ -151,14 +181,40 @@ defineProps<{
 	flex-shrink: 0;
 }
 
+.add-on-purchase-icon {
+	--v-icon-size: 18px;
+	margin-inline-end: 6px;
+}
+
+.add-on-upgrade-btn {
+	white-space: nowrap;
+	flex-shrink: 0;
+	--v-button-color: var(--theme--foreground-subdued);
+}
+
+.add-on-upgrade-icon {
+	--v-icon-color: var(--theme--foreground-subdued);
+	--v-icon-size: 18px;
+	margin-inline-end: 6px;
+}
+
 .add-on-title {
 	font-size: 14px;
 	font-weight: 600;
 	color: var(--theme--foreground);
 }
 
+.add-on-title--disabled {
+	color: var(--theme--foreground-subdued);
+}
+
 .add-on-description {
 	font-size: 13px;
 	color: var(--theme--foreground-subdued);
+}
+
+.add-on-description--disabled {
+	color: var(--theme--foreground-subdued);
+	opacity: 0.8;
 }
 </style>

--- a/app/src/modules/settings/routes/license/components/license-addons-section.vue
+++ b/app/src/modules/settings/routes/license/components/license-addons-section.vue
@@ -40,19 +40,15 @@ defineProps<{
 				{{ addonsError }}
 			</VNotice>
 			<template v-else>
-				<div v-for="pkg in addons" :key="pkg.id" class="add-on-card" :class="{ 'add-on-card--disabled': pkg.disabled }">
-					<div class="add-on-icon-wrapper" :class="{ 'add-on-icon-wrapper--disabled': pkg.disabled }">
+				<div v-for="pkg in addons" :key="pkg.id" class="add-on-card" :class="{ disabled: pkg.disabled }">
+					<div class="add-on-icon-wrapper" :class="{ disabled: pkg.disabled }">
 						<VIcon :name="pkg.icon" class="add-on-icon" />
 					</div>
 					<div class="add-on-content">
-						<span class="add-on-title" :class="{ 'add-on-title--disabled': pkg.disabled }">
+						<span class="add-on-title" :class="{ disabled: pkg.disabled }">
 							{{ pkg.name }}
 						</span>
-						<span
-							v-if="pkg.description"
-							class="add-on-description"
-							:class="{ 'add-on-description--disabled': pkg.disabled }"
-						>
+						<span v-if="pkg.description" class="add-on-description" :class="{ disabled: pkg.disabled }">
 							{{ pkg.description }}
 						</span>
 					</div>
@@ -148,11 +144,11 @@ defineProps<{
 	flex-shrink: 0;
 }
 
-.add-on-icon-wrapper--disabled {
+.add-on-icon-wrapper.disabled {
 	background: var(--theme--background-normal);
 }
 
-.add-on-icon-wrapper--disabled .add-on-icon {
+.add-on-icon-wrapper.disabled .add-on-icon {
 	--v-icon-color: var(--theme--foreground-subdued);
 }
 
@@ -205,7 +201,7 @@ defineProps<{
 	color: var(--theme--foreground);
 }
 
-.add-on-title--disabled {
+.add-on-title.disabled {
 	color: var(--theme--foreground-subdued);
 }
 
@@ -214,7 +210,7 @@ defineProps<{
 	color: var(--theme--foreground-subdued);
 }
 
-.add-on-description--disabled {
+.add-on-description.disabled {
 	color: var(--theme--foreground-subdued);
 	opacity: 0.8;
 }

--- a/app/src/modules/settings/routes/license/components/license-addons-section.vue
+++ b/app/src/modules/settings/routes/license/components/license-addons-section.vue
@@ -189,6 +189,7 @@ defineProps<{
 .add-on-upgrade-btn {
 	white-space: nowrap;
 	flex-shrink: 0;
+
 	--v-button-color: var(--theme--foreground-subdued);
 }
 

--- a/app/src/modules/settings/routes/license/components/license-usage-section.vue
+++ b/app/src/modules/settings/routes/license/components/license-usage-section.vue
@@ -28,9 +28,7 @@ const { t } = useI18n();
 
 const displayLabelIncluded = computed(() => props.labelIncluded ?? t('settings_license_usage_available'));
 
-const displayLabelNotIncluded = computed(
-	() => props.labelNotIncluded ?? t('settings_license_usage_unavailable'),
-);
+const displayLabelNotIncluded = computed(() => props.labelNotIncluded ?? t('settings_license_usage_unavailable'));
 
 const displayLabelOptional = computed(() => props.labelOptional ?? t('settings_license_usage_opt_in'));
 </script>

--- a/app/src/modules/settings/routes/license/components/license-usage-section.vue
+++ b/app/src/modules/settings/routes/license/components/license-usage-section.vue
@@ -1,18 +1,38 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
+import VChip from '@/components/v-chip.vue';
 import VIcon from '@/components/v-icon/v-icon.vue';
 
-defineProps<{
-	collectionsCount: number;
-	collectionsLimit: number;
-	usersCount: number;
-	usersLimit: number;
-	customRulesAvailable: boolean;
-	customLlmAvailable: boolean;
-	ssoAvailable: boolean;
-}>();
+const props = withDefaults(
+	defineProps<{
+		collectionsCount: number;
+		collectionsLimit: number;
+		usersCount: number;
+		usersLimit: number;
+		customRulesAvailable: boolean;
+		customLlmAvailable: boolean;
+		ssoAvailable: boolean;
+		labelIncluded?: string;
+		labelNotIncluded?: string;
+		labelOptional?: string;
+	}>(),
+	{
+		labelIncluded: undefined,
+		labelNotIncluded: undefined,
+		labelOptional: undefined,
+	},
+);
 
 const { t } = useI18n();
+
+const displayLabelIncluded = computed(() => props.labelIncluded ?? t('settings_license_usage_available'));
+
+const displayLabelNotIncluded = computed(
+	() => props.labelNotIncluded ?? t('settings_license_usage_unavailable'),
+);
+
+const displayLabelOptional = computed(() => props.labelOptional ?? t('settings_license_usage_opt_in'));
 </script>
 
 <template>
@@ -29,8 +49,10 @@ const { t } = useI18n();
 			<div class="usage-item">
 				<VIcon name="admin_panel_settings" class="usage-icon" />
 				<span class="usage-label">{{ t('settings_license_usage_custom_rules') }}</span>
-				<span :class="['usage-badge', customRulesAvailable ? 'badge-available' : 'badge-unavailable']">
-					{{ customRulesAvailable ? t('settings_license_usage_available') : t('settings_license_usage_unavailable') }}
+				<span :class="customRulesAvailable ? 'badge-available' : 'badge-unavailable'">
+					<VChip small>
+						{{ customRulesAvailable ? displayLabelIncluded : displayLabelNotIncluded }}
+					</VChip>
 				</span>
 			</div>
 			<div class="usage-item">
@@ -41,22 +63,26 @@ const { t } = useI18n();
 			<div class="usage-item">
 				<VIcon name="smart_toy" class="usage-icon" />
 				<span class="usage-label">{{ t('settings_license_usage_custom_llm') }}</span>
-				<span :class="['usage-badge', customLlmAvailable ? 'badge-available' : 'badge-unavailable']">
-					{{ customLlmAvailable ? t('settings_license_usage_available') : t('settings_license_usage_unavailable') }}
+				<span :class="customLlmAvailable ? 'badge-available' : 'badge-unavailable'">
+					<VChip small>
+						{{ customLlmAvailable ? displayLabelIncluded : displayLabelNotIncluded }}
+					</VChip>
 				</span>
 			</div>
 			<div class="usage-item">
 				<VIcon name="cloud_lock" class="usage-icon" />
 				<span class="usage-label">{{ t('settings_license_usage_sso') }}</span>
-				<span :class="['usage-badge', ssoAvailable ? 'badge-available' : 'badge-unavailable']">
-					{{ ssoAvailable ? t('settings_license_usage_available') : t('settings_license_usage_unavailable') }}
+				<span :class="ssoAvailable ? 'badge-available' : 'badge-unavailable'">
+					<VChip small>
+						{{ ssoAvailable ? displayLabelIncluded : displayLabelNotIncluded }}
+					</VChip>
 				</span>
 			</div>
 			<div class="usage-item">
 				<VIcon name="bar_chart" class="usage-icon" />
 				<span class="usage-label">{{ t('settings_license_usage_analytics') }}</span>
-				<span class="usage-badge badge-unavailable">
-					{{ t('settings_license_usage_opt_in') }}
+				<span class="badge-unavailable">
+					<VChip small>{{ displayLabelOptional }}</VChip>
 				</span>
 			</div>
 		</div>
@@ -113,21 +139,21 @@ const { t } = useI18n();
 	flex-shrink: 0;
 }
 
-.usage-badge {
-	font-size: 12px;
-	font-weight: 500;
-	padding: 2px 8px;
-	border-radius: 8px;
+.badge-available,
+.badge-unavailable {
+	display: inline-flex;
 	flex-shrink: 0;
 }
 
 .badge-available {
-	background: var(--theme--background-success);
-	color: var(--theme--foreground-success);
+	--v-chip-color: var(--theme--success);
+	--v-chip-background-color: var(--theme--success-background);
+	--v-chip-border-color: var(--theme--success-background);
 }
 
 .badge-unavailable {
-	background: var(--theme--background-subdued);
-	color: var(--theme--foreground-subdued);
+	--v-chip-color: var(--theme--foreground-subdued);
+	--v-chip-background-color: var(--theme--background-subdued);
+	--v-chip-border-color: var(--theme--background-subdued);
 }
 </style>

--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -217,18 +217,22 @@ function onLicenseKeyInput(v: string) {
 	};
 }
 
-const ADDON_ICON_MAP: Record<string, string> = {
-	sso: 'cloud_lock',
-	user_seats: 'group',
-	collections: 'inventory_2',
-};
-
-function mapAddonToDisplay(item: { id: string; name: string; description: string; status: string; action: string }) {
+function mapAddonToDisplay(item: {
+	id: string;
+	name: string;
+	description: string;
+	status: string;
+	action: string;
+	icon?: string;
+	disabled?: boolean;
+}) {
 	return {
 		...item,
-		icon: ADDON_ICON_MAP[item.id] ?? 'extension',
-		showPurchase: item.action === 'purchase',
+		icon: item.icon ?? 'extension',
+		disabled: item.disabled ?? false,
+		showPurchase: !(item.disabled ?? false) && item.action === 'purchase',
 		showInfo: item.action === 'info',
+		showUpgradePlan: item.disabled ?? false,
 	};
 }
 

--- a/app/src/stores/server.test.ts
+++ b/app/src/stores/server.test.ts
@@ -82,6 +82,8 @@ describe('hydrate action', async () => {
 				description: 'Allows SSO configuration',
 				status: 'available',
 				action: 'purchase',
+				icon: 'cloud_lock',
+				disabled: false,
 			},
 		];
 

--- a/app/src/stores/server.ts
+++ b/app/src/stores/server.ts
@@ -109,6 +109,8 @@ export type Addon = {
 		description: string;
 		status: 'available' | 'purchased';
 		action: 'purchase' | 'info';
+		icon?: string;
+		disabled?: boolean;
 	}[];
 };
 


### PR DESCRIPTION
## Scope

## What's changed

### DIR-69: [Plan Usage] Update feature status labels to Included/Not Included
- Updated status labels in the "Your Plan Usage" section from `Enabled` / `Disabled` / `Opt-in` to `Included` / `Not Included` / `Optional`
- Applied to SSO, Custom Rules (Access Policies), Custom LLM, and Analytics feature items

### DIR-70: [Plan Usage] Allow custom label for feature items
- Allowed plan configuration to pass custom labels for each feature item instead of using hardcoded status text
- Added configurable label props so labels can be rendered dynamically
- Extended `LicenseAddon` with optional `icon` and `disabled` fields
- Add-on icons are now driven by API data instead of hardcoded mapping
- Implemented disabled state for add-on items (muted icon, title, description)
- Active add-ons show "Purchase" CTA with shopping cart icon
- Disabled add-ons show "Upgrade Plan" CTA with diamond icon
- Added mock data for User Seats, SSO Feature, Data Model Collections, and Basic Support

### DIR-71: [Add-on Packages] Add disabled state for non-purchasable items
- Some items in the "Add-on Packages" section (e.g. Data Model Collections, Basic Support) now have a disabled state
- Disabled state shows greyed out / muted styling
- Replaced "Purchase" button with "Upgrade Plan" button for disabled items

## Potential Risks / Drawbacks

N/A

## Tested Scenarios

N/A

## Review Notes / Questions

N/A

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---
<img width="1781" height="967" alt="image" src="https://github.com/user-attachments/assets/6e87f53a-6206-4271-b553-bde12eacd453" />

Fixes #\<num\>
