### PR TITLE
DIR-53: add methods to archive users and exclude collections

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -99,6 +99,8 @@ settings_license_deactivation_popup_notice_and: ' and '
 settings_license_deactivate_confirm:
   Are you sure you want to deactivate the license? This will remove the license from this project.
 settings_license_deactivate_success: License deactivated successfully
+error_archiving_users: Failed to deactivate selected users.
+error_excluding_collections: Failed to deactivate selected collections.
 license_valid: License Valid
 license_invalid: Invalid License Key
 license_expires_on: 'Expires on {date}'

--- a/app/src/modules/settings/routes/license/components/deactivation-popup.vue
+++ b/app/src/modules/settings/routes/license/components/deactivation-popup.vue
@@ -179,17 +179,21 @@ async function excludeCollections(collectionKeys: string[]) {
 async function handleDeactivation() {
 	if (selectedUsers.value.length > 0) {
 		const response = await archiveUsers(selectedUsers.value);
+
 		if (!response) {
 			notify({ title: t('error_archiving_users') });
 		}
+
 		return;
 	}
 
 	if (selectedCollections.value.length > 0) {
 		const response = await excludeCollections(selectedCollections.value);
+
 		if (!response) {
 			notify({ title: t('error_excluding_collections') });
 		}
+
 		return;
 	}
 

--- a/app/src/modules/settings/routes/license/components/deactivation-popup.vue
+++ b/app/src/modules/settings/routes/license/components/deactivation-popup.vue
@@ -142,6 +142,59 @@ async function deactivateLicense() {
 		deactivating.value = false;
 	}
 }
+
+async function archiveUsers(userIds: string[]) {
+	if (!userIds.length) return;
+
+	try {
+		const response = await api.patch(
+			'/users',
+			userIds.map((id) => ({ id, status: 'archived' })),
+		);
+
+		return response?.data?.data;
+	} catch (error: unknown) {
+		unexpectedError(error);
+	}
+}
+
+async function excludeCollections(collectionKeys: string[]) {
+	if (!collectionKeys.length) return;
+
+	try {
+		const response = await api.patch(
+			'/collections',
+			collectionKeys.map((collection) => ({
+				collection,
+				meta: { excluded: true },
+			})),
+		);
+
+		return response?.data?.data;
+	} catch (error: unknown) {
+		unexpectedError(error);
+	}
+}
+
+async function handleDeactivation() {
+	if (selectedUsers.value.length > 0) {
+		const response = await archiveUsers(selectedUsers.value);
+		if (!response) {
+			notify({ title: t('error_archiving_users') });
+		}
+		return;
+	}
+
+	if (selectedCollections.value.length > 0) {
+		const response = await excludeCollections(selectedCollections.value);
+		if (!response) {
+			notify({ title: t('error_excluding_collections') });
+		}
+		return;
+	}
+
+	await deactivateLicense();
+}
 </script>
 
 <template>
@@ -190,7 +243,7 @@ async function deactivateLicense() {
 				<VButton secondary @click="confirmDeactivate = false">
 					{{ t('cancel') }}
 				</VButton>
-				<VButton kind="danger" :loading="deactivating" @click="deactivateLicense">
+				<VButton kind="danger" :loading="deactivating" @click="handleDeactivation">
 					{{ t('settings_license_deactivation_popup_confirm') }}
 				</VButton>
 			</div>


### PR DESCRIPTION
## Scope

What's changed:
- Add method to call PATCH `/users` endpoint to bulk update users status to inactive in deactivation popup
- Add method to call PATCH `/collections` endpoint to bulk update collections excluded to true in deactivation popup
- Add method to handle deactivate license by calling 3 methods

## Potential Risks / Drawbacks
- N/A

## Tested Scenarios
- N/A

## Review Notes / Questions
- N/A

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #\<num\>
