### PR TITLE
DIR-55: handle api restriction for the excluded collections

### DIFF
--- a/api/src/controllers/collections.ts
+++ b/api/src/controllers/collections.ts
@@ -1,9 +1,6 @@
 import { ErrorCode, isDirectusError, LimitExceededError } from '@directus/errors';
-import { isSystemCollection } from '@directus/system-data';
 import type { Item } from '@directus/types';
 import { Router } from 'express';
-import getDatabase from '../database/index.js';
-import { getFeature } from '../license/index.js';
 import { respond } from '../middleware/respond.js';
 import { validateBatch } from '../middleware/validate-batch.js';
 import { CollectionsService } from '../services/collections.js';
@@ -23,16 +20,10 @@ router.post(
 		const attemptConcurrentIndex =
 			'concurrentIndexCreation' in req.query && req.query['concurrentIndexCreation'] !== 'false';
 
-		const db = getDatabase();
-		const allCollections = await db('directus_collections').select('collection');
-		const collectionsCount = allCollections.filter(({ collection }) => !isSystemCollection(collection)).length;
-
-		const collectionFeature = await getFeature<{ limit: number }>('collections');
-		const collectionsLimit = collectionFeature?.limit;
-
 		const newCollectionsCount = Array.isArray(req.body) ? req.body.length : 1;
+		const isWithinLimit = await collectionsService.checkAddingLimit(newCollectionsCount);
 
-		if (collectionsLimit && collectionsCount + newCollectionsCount > collectionsLimit) {
+		if (!isWithinLimit) {
 			throw new LimitExceededError({ category: 'collections' });
 		}
 
@@ -109,6 +100,29 @@ router.patch(
 			schema: req.schema,
 		});
 
+		let newAdded = 0;
+		let newExcluded = 0;
+
+		for (const collection of req.body) {
+			if (collection.meta?.excluded === false) {
+				newAdded++;
+			}
+
+			if (collection.meta?.excluded === true) {
+				newExcluded++;
+			}
+		}
+
+		const newCount = newAdded - newExcluded;
+
+		if (newCount > 0) {
+			const isWithinLimit = await collectionsService.checkAddingLimit(newCount);
+
+			if (!isWithinLimit) {
+				throw new LimitExceededError({ category: 'collections' });
+			}
+		}
+
 		const collectionKeys = await collectionsService.updateBatch(req.body);
 
 		try {
@@ -134,6 +148,16 @@ router.patch(
 			accountability: req.accountability,
 			schema: req.schema,
 		});
+
+		const excluded = req.body?.meta?.excluded;
+
+		if (excluded === false) {
+			const isWithinLimit = await collectionsService.checkAddingLimit(1);
+
+			if (!isWithinLimit) {
+				throw new LimitExceededError({ category: 'collections' });
+			}
+		}
 
 		await collectionsService.updateOne(req.params['collection']!, req.body);
 

--- a/api/src/controllers/collections.ts
+++ b/api/src/controllers/collections.ts
@@ -1,6 +1,7 @@
 import { ErrorCode, isDirectusError, LimitExceededError } from '@directus/errors';
 import type { Item } from '@directus/types';
 import { Router } from 'express';
+import { isNil } from 'lodash-es';
 import { respond } from '../middleware/respond.js';
 import { validateBatch } from '../middleware/validate-batch.js';
 import { CollectionsService } from '../services/collections.js';
@@ -104,11 +105,21 @@ router.patch(
 		let newExcluded = 0;
 
 		for (const collection of req.body) {
-			if (collection.meta?.excluded === false) {
+			if (!isNil(collection.meta)) {
+				const isExisted = await collectionsService.isExisted(collection.collection);
+
+				if (!isExisted) {
+					newAdded++;
+				}
+			}
+
+			const isCurrentlyExcluded = await collectionsService.isExcluded(collection.collection!);
+
+			if (!collection.meta?.excluded && isCurrentlyExcluded) {
 				newAdded++;
 			}
 
-			if (collection.meta?.excluded === true) {
+			if (collection.meta?.excluded && !isCurrentlyExcluded) {
 				newExcluded++;
 			}
 		}
@@ -149,9 +160,25 @@ router.patch(
 			schema: req.schema,
 		});
 
-		const excluded = req.body?.meta?.excluded;
+		let checkLimitForDbOnlyCollection = false;
+		const meta = req.body?.meta;
 
-		if (excluded === false) {
+		if (!isNil(meta)) {
+			const isExisted = await collectionsService.isExisted(req.params['collection']!);
+			checkLimitForDbOnlyCollection = !isExisted;
+		}
+
+		let checkLimitForExcludedCollection = false;
+		const excluded = meta?.excluded;
+
+		if (!excluded) {
+			const isCurrentlyExcluded = await collectionsService.isExcluded(req.params['collection']!);
+			checkLimitForExcludedCollection = !!isCurrentlyExcluded;
+		}
+
+		const shouldCheckLimit = checkLimitForDbOnlyCollection || checkLimitForExcludedCollection;
+
+		if (shouldCheckLimit) {
 			const isWithinLimit = await collectionsService.checkAddingLimit(1);
 
 			if (!isWithinLimit) {

--- a/api/src/controllers/fields.ts
+++ b/api/src/controllers/fields.ts
@@ -6,6 +6,7 @@ import type { Field, RawField, Type } from '@directus/types';
 import { Router } from 'express';
 import Joi from 'joi';
 import { ALIAS_TYPES } from '../constants.js';
+import collectionExcluded from '../middleware/collection-excluded.js';
 import validateCollection from '../middleware/collection-exists.js';
 import { respond } from '../middleware/respond.js';
 import useCollection from '../middleware/use-collection.js';
@@ -86,6 +87,7 @@ const newFieldSchema = Joi.object({
 router.post(
 	'/:collection',
 	validateCollection,
+	collectionExcluded,
 	asyncHandler(async (req, res, next) => {
 		const service = new FieldsService({
 			accountability: req.accountability,
@@ -124,6 +126,7 @@ router.post(
 router.patch(
 	'/:collection',
 	validateCollection,
+	collectionExcluded,
 	asyncHandler(async (req, res, next) => {
 		const service = new FieldsService({
 			accountability: req.accountability,
@@ -187,6 +190,7 @@ const updateSchema = Joi.object({
 router.patch(
 	'/:collection/:field',
 	validateCollection,
+	collectionExcluded,
 	asyncHandler(async (req, res, next) => {
 		const service = new FieldsService({
 			accountability: req.accountability,
@@ -233,6 +237,7 @@ router.patch(
 router.delete(
 	'/:collection/:field',
 	validateCollection,
+	collectionExcluded,
 	asyncHandler(async (req, _res, next) => {
 		const service = new FieldsService({
 			accountability: req.accountability,

--- a/api/src/controllers/items.ts
+++ b/api/src/controllers/items.ts
@@ -2,6 +2,7 @@ import { ErrorCode, ForbiddenError, isDirectusError, RouteNotFoundError } from '
 import { isSystemCollection } from '@directus/system-data';
 import type { PrimaryKey } from '@directus/types';
 import express from 'express';
+import collectionExcluded from '../middleware/collection-excluded.js';
 import collectionExists from '../middleware/collection-exists.js';
 import { respond } from '../middleware/respond.js';
 import { validateBatch } from '../middleware/validate-batch.js';
@@ -15,6 +16,7 @@ const router = express.Router();
 router.post(
 	'/:collection',
 	collectionExists,
+	collectionExcluded,
 	asyncHandler(async (req, res, next) => {
 		if (isSystemCollection(req.params['collection']!)) throw new ForbiddenError();
 
@@ -91,12 +93,13 @@ const readHandler = asyncHandler(async (req, res, next) => {
 	return next();
 });
 
-router.search('/:collection', collectionExists, validateBatch('read'), readHandler, respond);
-router.get('/:collection', collectionExists, readHandler, respond);
+router.search('/:collection', collectionExists, collectionExcluded, validateBatch('read'), readHandler, respond);
+router.get('/:collection', collectionExists, collectionExcluded, readHandler, respond);
 
 router.get(
 	'/:collection/:pk',
 	collectionExists,
+	collectionExcluded,
 	asyncHandler(async (req, res, next) => {
 		if (isSystemCollection(req.params['collection']!)) throw new ForbiddenError();
 
@@ -119,6 +122,7 @@ router.get(
 router.patch(
 	'/:collection',
 	collectionExists,
+	collectionExcluded,
 	validateBatch('update'),
 	asyncHandler(async (req, res, next) => {
 		if (isSystemCollection(req.params['collection']!)) throw new ForbiddenError();
@@ -166,6 +170,7 @@ router.patch(
 router.patch(
 	'/:collection/:pk',
 	collectionExists,
+	collectionExcluded,
 	asyncHandler(async (req, res, next) => {
 		if (isSystemCollection(req.params['collection']!)) throw new ForbiddenError();
 
@@ -199,6 +204,7 @@ router.patch(
 router.delete(
 	'/:collection',
 	collectionExists,
+	collectionExcluded,
 	validateBatch('delete'),
 	asyncHandler(async (req, _res, next) => {
 		if (isSystemCollection(req.params['collection']!)) throw new ForbiddenError();
@@ -225,6 +231,7 @@ router.delete(
 router.delete(
 	'/:collection/:pk',
 	collectionExists,
+	collectionExcluded,
 	asyncHandler(async (req, _res, next) => {
 		if (isSystemCollection(req.params['collection']!)) throw new ForbiddenError();
 

--- a/api/src/middleware/collection-excluded.test.ts
+++ b/api/src/middleware/collection-excluded.test.ts
@@ -1,0 +1,88 @@
+import type { Accountability, SchemaOverview } from '@directus/types';
+import type { Request, Response } from 'express';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { createCollectionExcludedError } from '../permissions/modules/process-ast/utils/validate-path/create-error.js';
+import { CollectionsService } from '../services/collections.js';
+import collectionExcluded from './collection-excluded.js';
+
+vi.mock('../services/collections.js', () => {
+	const CollectionsService = vi.fn();
+	CollectionsService.prototype.isExcluded = vi.fn().mockResolvedValue(false);
+	return { CollectionsService };
+});
+
+type CollectionExcludedError = Error & { code?: string };
+
+vi.mock('../permissions/modules/process-ast/utils/validate-path/create-error.js', () => ({
+	createCollectionExcludedError: vi.fn().mockImplementation((_path: string, collection: string) => {
+		const error: CollectionExcludedError = new Error(`Collection "${collection}" is excluded`);
+		error.code = 'FORBIDDEN';
+		return error;
+	}),
+}));
+
+describe('collectionExcluded middleware', () => {
+	let req: Request;
+	let res: Response;
+	let next: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		req = {
+			params: {},
+			accountability: undefined,
+			schema: {} as unknown as SchemaOverview,
+		} as unknown as Request;
+
+		res = {} as Response;
+		next = vi.fn();
+
+		vi.clearAllMocks();
+	});
+
+	test('calls next immediately when no collection param is present', async () => {
+		await collectionExcluded(req, res, next);
+
+		expect(CollectionsService).not.toHaveBeenCalled();
+		expect(next).toHaveBeenCalledTimes(1);
+		expect(next).toHaveBeenCalledWith();
+	});
+
+	test('creates CollectionsService with accountability and schema from request', async () => {
+		req.params['collection'] = 'articles';
+		req.accountability = { user: '1' } as Accountability;
+		req.schema = { collections: {}, fields: {}, relations: {} } as unknown as SchemaOverview;
+
+		await collectionExcluded(req, res, next);
+
+		expect(CollectionsService).toHaveBeenCalledWith({
+			accountability: req.accountability,
+			schema: req.schema,
+		});
+	});
+
+	test('calls next when collection is not excluded', async () => {
+		req.params['collection'] = 'articles';
+
+		const isExcludedSpy = vi.spyOn(CollectionsService.prototype, 'isExcluded').mockResolvedValueOnce(false);
+
+		await collectionExcluded(req, res, next);
+
+		expect(isExcludedSpy).toHaveBeenCalledWith('articles');
+		expect(next).toHaveBeenCalledTimes(1);
+		expect(next).toHaveBeenCalledWith();
+	});
+
+	test('calls next with collection excluded error when collection is excluded', async () => {
+		req.params['collection'] = 'articles';
+
+		vi.spyOn(CollectionsService.prototype, 'isExcluded').mockResolvedValueOnce(true);
+
+		const expectedError = createCollectionExcludedError('', 'articles');
+
+		await collectionExcluded(req, res, next);
+
+		expect(CollectionsService.prototype.isExcluded).toHaveBeenCalledWith('articles');
+		expect(next).toHaveBeenCalledTimes(1);
+		expect(next).toHaveBeenCalledWith(expectedError);
+	});
+});

--- a/api/src/middleware/collection-excluded.ts
+++ b/api/src/middleware/collection-excluded.ts
@@ -1,0 +1,27 @@
+import type { RequestHandler } from 'express';
+import { createCollectionExcludedError } from '../permissions/modules/process-ast/utils/validate-path/create-error.js';
+import { CollectionsService } from '../services/collections.js';
+import asyncHandler from '../utils/async-handler.js';
+
+/**
+ * Check if requested collection is marked as excluded.
+ * If so, throw the standard collection forbidden error.
+ */
+const collectionExcluded: RequestHandler = asyncHandler(async (req, _res, next) => {
+	if (!req.params['collection']) return next();
+
+	const collectionsService = new CollectionsService({
+		accountability: req.accountability,
+		schema: req.schema,
+	});
+
+	const isExcluded = await collectionsService.isExcluded(req.params['collection']!);
+
+	if (isExcluded) {
+		throw createCollectionExcludedError('', req.params['collection']!);
+	}
+
+	return next();
+});
+
+export default collectionExcluded;

--- a/api/src/permissions/modules/process-ast/utils/validate-path/create-error.ts
+++ b/api/src/permissions/modules/process-ast/utils/validate-path/create-error.ts
@@ -8,6 +8,14 @@ export function createCollectionForbiddenError(path: string, collection: string)
 	});
 }
 
+export function createCollectionExcludedError(path: string, collection: string): DirectusError<any> {
+	const pathSuffix = path === '' ? 'root' : `"${path}"`;
+
+	return new ForbiddenError({
+		reason: `The collection "${collection}" is excluded. Queried in ${pathSuffix}.`,
+	});
+}
+
 export function createFieldsForbiddenError(path: string, collection: string, fields: string[]): DirectusError<any> {
 	const pathSuffix = path === '' ? 'root' : `"${path}"`;
 

--- a/api/src/services/collections.test.ts
+++ b/api/src/services/collections.test.ts
@@ -187,6 +187,42 @@ describe('Integration Tests', () => {
 			});
 		});
 
+		describe('isExcluded', () => {
+			test('should return true when collection is marked as excluded', async () => {
+				const service = new CollectionsService({
+					knex: db,
+					schema,
+					accountability: null,
+				});
+
+				tracker.on.select('directus_collections').responseOnce([{ excluded: true }]);
+
+				const result = await service.isExcluded('articles');
+
+				expect(result).toBe(true);
+			});
+
+			test('should return false when collection is not excluded or excluded is null', async () => {
+				const service = new CollectionsService({
+					knex: db,
+					schema,
+					accountability: null,
+				});
+
+				tracker.on.select('directus_collections').responseOnce([{ excluded: false }]);
+
+				const resultFalse = await service.isExcluded('articles');
+
+				expect(resultFalse).toBe(false);
+
+				tracker.on.select('directus_collections').responseOnce([{}]);
+
+				const resultNull = await service.isExcluded('articles');
+
+				expect(resultNull).toBe(false);
+			});
+		});
+
 		describe('createOne', () => {
 			test('should throw ForbiddenError for non-admin users', async () => {
 				const service = new CollectionsService({

--- a/api/src/services/collections.test.ts
+++ b/api/src/services/collections.test.ts
@@ -13,9 +13,21 @@ vi.mock('@directus/env', () => ({
 	useEnv: vi.fn().mockReturnValue({}),
 }));
 
-vi.mock('../../src/database/index', async () => {
-	const { mockDatabase } = await import('../test-utils/database.js');
-	return mockDatabase();
+vi.mock('../../src/database/index', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../../src/database/index.js')>();
+
+	const fakeKnex = {
+		select: vi.fn().mockReturnThis(),
+		from: vi.fn().mockReturnThis(),
+		first: vi.fn().mockResolvedValue({}),
+	};
+
+	return {
+		...actual,
+		getDatabaseClient: vi.fn().mockReturnValue('postgres'),
+		getSchemaInspector: vi.fn(),
+		getDatabase: vi.fn().mockReturnValue(fakeKnex),
+	};
 });
 
 vi.mock('@directus/schema', async () => {

--- a/api/src/services/collections.test.ts
+++ b/api/src/services/collections.test.ts
@@ -107,6 +107,74 @@ describe('Integration Tests', () => {
 	});
 
 	describe('Services / Collections', () => {
+		describe('checkAddingLimit', () => {
+			test('should return true when feature has no limit configured', async () => {
+				const service = new CollectionsService({
+					knex: db,
+					schema,
+					accountability: null,
+				});
+
+				tracker.on
+					.select('directus_collections')
+					.response([{ collection: 'test_collection' }, { collection: 'directus_roles' }]);
+
+				const result = await service.checkAddingLimit(3);
+
+				expect(result).toBe(true);
+			});
+
+			test('should return true when total non-system collections after adding is within limit', async () => {
+				const service = new CollectionsService({
+					knex: db,
+					schema,
+					accountability: null,
+				});
+
+				tracker.on
+					.select('directus_collections')
+					.response([{ collection: 'public_articles' }, { collection: 'directus_users' }]);
+
+				const mockFeature = { limit: 5 };
+
+				const getFeatureSpy = vi
+					.spyOn(await import('../license/index.js'), 'getFeature')
+					.mockResolvedValue(mockFeature);
+
+				const result = await service.checkAddingLimit(2);
+
+				expect(result).toBe(true);
+				expect(getFeatureSpy).toHaveBeenCalledWith('collections');
+			});
+
+			test('should return false when total non-system collections after adding exceeds limit', async () => {
+				const service = new CollectionsService({
+					knex: db,
+					schema,
+					accountability: null,
+				});
+
+				tracker.on
+					.select('directus_collections')
+					.response([
+						{ collection: 'public_articles' },
+						{ collection: 'public_comments' },
+						{ collection: 'directus_users' },
+					]);
+
+				const mockFeature = { limit: 2 };
+
+				const getFeatureSpy = vi
+					.spyOn(await import('../license/index.js'), 'getFeature')
+					.mockResolvedValue(mockFeature);
+
+				const result = await service.checkAddingLimit(1);
+
+				expect(result).toBe(false);
+				expect(getFeatureSpy).toHaveBeenCalledWith('collections');
+			});
+		});
+
 		describe('createOne', () => {
 			test('should throw ForbiddenError for non-admin users', async () => {
 				const service = new CollectionsService({

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -848,7 +848,12 @@ export class CollectionsService {
 	 * Verify if creating new collections is within the limit
 	 */
 	async checkAddingLimit(count: number): Promise<boolean> {
-		const allCollections = await this.knex.select('collection').from('directus_collections');
+		const allCollections = await this.knex
+			.select('collection')
+			.from('directus_collections')
+			.where({ excluded: false })
+			.orWhereNull('excluded');
+
 		const collectionsCount = allCollections.filter(({ collection }) => !isSystemCollection(collection)).length;
 
 		const collectionFeature = await getFeature<{ limit: number }>('collections');

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -878,4 +878,17 @@ export class CollectionsService {
 
 		return collection?.excluded === true;
 	}
+
+	/**
+	 * Check if a collection exists
+	 */
+	async isExisted(collectionKey: string): Promise<boolean> {
+		const collection = await this.knex
+			.select('collection')
+			.from('directus_collections')
+			.where({ collection: collectionKey })
+			.first();
+
+		return collection !== undefined;
+	}
 }

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -3,6 +3,7 @@ import { ForbiddenError, InvalidPayloadError } from '@directus/errors';
 import type { SchemaInspector } from '@directus/schema';
 import { createInspector } from '@directus/schema';
 import { type BaseCollectionMeta, systemCollectionRows } from '@directus/system-data';
+import { isSystemCollection } from '@directus/system-data';
 import type {
 	AbstractServiceOptions,
 	Accountability,
@@ -24,6 +25,7 @@ import type { Helpers } from '../database/helpers/index.js';
 import { getHelpers } from '../database/helpers/index.js';
 import getDatabase, { getSchemaInspector } from '../database/index.js';
 import emitter from '../emitter.js';
+import { getFeature } from '../license/index.js';
 import { fetchAllowedCollections } from '../permissions/modules/fetch-allowed-collections/fetch-allowed-collections.js';
 import { validateAccess } from '../permissions/modules/validate-access/validate-access.js';
 import type { Collection } from '../types/index.js';
@@ -840,5 +842,35 @@ export class CollectionsService {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Verify if creating new collections is within the limit
+	 */
+	async checkAddingLimit(count: number): Promise<boolean> {
+		const allCollections = await this.knex.select('collection').from('directus_collections');
+		const collectionsCount = allCollections.filter(({ collection }) => !isSystemCollection(collection)).length;
+
+		const collectionFeature = await getFeature<{ limit: number }>('collections');
+		const collectionsLimit = collectionFeature?.limit;
+
+		if (collectionsLimit && collectionsCount + count > collectionsLimit) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check if a collection is excluded
+	 */
+	async isExcluded(collectionKey: string): Promise<boolean> {
+		const collection = await this.knex
+			.select('excluded')
+			.from('directus_collections')
+			.where({ collection: collectionKey })
+			.first();
+
+		return collection?.excluded === true;
 	}
 }

--- a/api/src/services/server.ts
+++ b/api/src/services/server.ts
@@ -97,7 +97,11 @@ export class ServerService {
 					logger.warn(error, '[license] Failed to load collections feature entitlements');
 				}
 
-				const allCollections = await this.knex('directus_collections').select('collection');
+				const allCollections = await this.knex('directus_collections')
+					.select('collection')
+					.where({ excluded: false })
+					.orWhereNull('excluded');
+
 				const collectionsCount = allCollections.filter(({ collection }) => !isSystemCollection(collection)).length;
 				entitlements.collections.usage = collectionsCount;
 


### PR DESCRIPTION
## Scope

What's changed:
- Validate the limit when updating collection(s) to toggle `exclude` value OR to update db-only table to directus table
- Restrict all `items` endpoint for excluded collections
- Restrict all `fields` endpoints except GET endpoint(s) for excluded collections

## Potential Risks / Drawbacks
- N/A

## Tested Scenarios
- N/A

## Review Notes / Questions
- N/A

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #\<num\>
