### PR TITLE
DIR-82: handle deactivated user restriction and limit checking

### DIFF
--- a/api/src/controllers/collections.ts
+++ b/api/src/controllers/collections.ts
@@ -1,7 +1,7 @@
 import { ErrorCode, isDirectusError, LimitExceededError } from '@directus/errors';
 import type { Item } from '@directus/types';
 import { Router } from 'express';
-import { isNil } from 'lodash-es';
+import { isNil, isNull } from 'lodash-es';
 import { respond } from '../middleware/respond.js';
 import { validateBatch } from '../middleware/validate-batch.js';
 import { CollectionsService } from '../services/collections.js';
@@ -114,12 +114,13 @@ router.patch(
 			}
 
 			const isCurrentlyExcluded = await collectionsService.isExcluded(collection.collection!);
+			const excludedValue = collection.meta?.excluded;
 
-			if (!collection.meta?.excluded && isCurrentlyExcluded) {
+			if ((isNull(excludedValue) || excludedValue === false) && isCurrentlyExcluded) {
 				newAdded++;
 			}
 
-			if (collection.meta?.excluded && !isCurrentlyExcluded) {
+			if (excludedValue && !isCurrentlyExcluded) {
 				newExcluded++;
 			}
 		}
@@ -171,7 +172,7 @@ router.patch(
 		let checkLimitForExcludedCollection = false;
 		const excluded = meta?.excluded;
 
-		if (!excluded) {
+		if (isNull(excluded) || excluded === false) {
 			const isCurrentlyExcluded = await collectionsService.isExcluded(req.params['collection']!);
 			checkLimitForExcludedCollection = !!isCurrentlyExcluded;
 		}

--- a/api/src/controllers/users.ts
+++ b/api/src/controllers/users.ts
@@ -9,9 +9,9 @@ import {
 import type { PrimaryKey, RegisterUserInput } from '@directus/types';
 import express from 'express';
 import Joi from 'joi';
+import { isUndefined } from 'lodash-es';
 import { DEFAULT_AUTH_PROVIDER } from '../constants.js';
 import { getDatabase } from '../database/index.js';
-import { getFeature } from '../license/index.js';
 import checkRateLimit from '../middleware/rate-limiter-registration.js';
 import { respond } from '../middleware/respond.js';
 import useCollection from '../middleware/use-collection.js';
@@ -30,22 +30,17 @@ router.use(useCollection('directus_users'));
 router.post(
 	'/',
 	asyncHandler(async (req, res, next) => {
-		const db = getDatabase();
-		const usersCountResult = await db('directus_users').where('status', 'active').count({ count: '*' }).first();
-		const usersCount = Number(usersCountResult?.['count'] ?? 0);
-		const newUsersCount = Array.isArray(req.body) ? req.body.length : 1;
-
-		const usersFeature = await getFeature<{ limit?: number }>('users');
-		const usersLimit = usersFeature?.limit;
-
-		if (usersLimit && usersCount + newUsersCount > usersLimit) {
-			throw new LimitExceededError({ category: 'users' });
-		}
-
 		const service = new UsersService({
 			accountability: req.accountability,
 			schema: req.schema,
 		});
+
+		const newUsersCount = Array.isArray(req.body) ? req.body.length : 1;
+		const isWithinLimit = await service.checkAddingLimit(newUsersCount);
+
+		if (!isWithinLimit) {
+			throw new LimitExceededError({ category: 'users' });
+		}
 
 		const savedKeys: PrimaryKey[] = [];
 
@@ -205,6 +200,29 @@ router.patch(
 			schema: req.schema,
 		});
 
+		let newAdded = 0;
+		let newExcluded = 0;
+
+		for (const user of req.body) {
+			const isActive = await service.isActive(user.id);
+
+			if (user.status === 'active' && !isActive) {
+				newAdded++;
+			} else if (!isUndefined(user.status) && user.status !== 'active' && isActive) {
+				newExcluded++;
+			}
+		}
+
+		const newCount = newAdded - newExcluded;
+
+		if (newCount > 0) {
+			const isWithinLimit = await service.checkAddingLimit(newCount);
+
+			if (!isWithinLimit) {
+				throw new LimitExceededError({ category: 'users' });
+			}
+		}
+
 		let keys: PrimaryKey[] = [];
 
 		if (Array.isArray(req.body)) {
@@ -239,6 +257,15 @@ router.patch(
 			accountability: req.accountability,
 			schema: req.schema,
 		});
+
+		if (req.body?.status === 'active') {
+			const isActive = await service.isActive(req.params['pk']!);
+			const isWithinLimit = await service.checkAddingLimit(1);
+
+			if (!isActive && !isWithinLimit) {
+				throw new LimitExceededError({ category: 'users' });
+			}
+		}
 
 		const primaryKey = await service.updateOne(req.params['pk']!, req.body);
 
@@ -312,6 +339,12 @@ router.post(
 			accountability: req.accountability,
 			schema: req.schema,
 		});
+
+		const isWithinLimit = await service.checkAddingLimit(1);
+
+		if (!isWithinLimit) {
+			throw new LimitExceededError({ category: 'users' });
+		}
 
 		await service.inviteUser(req.body.email, req.body.role, req.body.invite_url || null);
 		return next();
@@ -475,6 +508,12 @@ router.post(
 		if (error) throw new InvalidPayloadError({ reason: error.message });
 
 		const usersService = new UsersService({ accountability: null, schema: req.schema });
+		const isWithinLimit = await usersService.checkAddingLimit(1);
+
+		if (!isWithinLimit) {
+			throw new LimitExceededError({ category: 'users' });
+		}
+
 		await usersService.registerUser(value);
 
 		return next();
@@ -494,6 +533,12 @@ router.get(
 		}
 
 		const service = new UsersService({ accountability: null, schema: req.schema });
+		const isWithinLimit = await service.checkAddingLimit(1);
+
+		if (!isWithinLimit) {
+			throw new LimitExceededError({ category: 'users' });
+		}
+
 		const id = await service.verifyRegistration(value);
 
 		return res.redirect(`/admin/users/${id}`);

--- a/api/src/services/authentication.test.ts
+++ b/api/src/services/authentication.test.ts
@@ -1,10 +1,16 @@
-import { InvalidCredentialsError, InvalidOtpError, ServiceUnavailableError } from '@directus/errors';
+import {
+	InvalidCredentialsError,
+	InvalidOtpError,
+	ServiceUnavailableError,
+	UserSuspendedError,
+} from '@directus/errors';
 import { SchemaBuilder } from '@directus/schema-builder';
 import knex, { type Knex } from 'knex';
 import { createTracker, MockClient, type Tracker } from 'knex-mock-client';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, type MockedFunction, vi } from 'vitest';
 import { getAuthProvider } from '../auth.js';
 import emitter from '../emitter.js';
+import { stall } from '../utils/stall.js';
 import { ActivityService } from './activity.js';
 import { AuthenticationService } from './authentication.js';
 import { SettingsService } from './settings.js';
@@ -360,6 +366,72 @@ describe('Integration Tests', () => {
 					refreshToken: 'test-refresh-token',
 					id: mockUser.id,
 				});
+			});
+		});
+
+		describe('refresh', () => {
+			it('should delete session, stall, and throw UserSuspendedError when user is suspended', async () => {
+				const refreshToken = 'old-refresh-token';
+
+				tracker.on.select('directus_sessions').responseOnce([
+					{
+						session_expires: new Date(Date.now() + 60_000),
+						session_next_token: null,
+						user_id: mockUser.id,
+						user_first_name: mockUser.first_name,
+						user_last_name: mockUser.last_name,
+						user_email: mockUser.email,
+						user_password: mockUser.password,
+						user_status: 'suspended',
+						user_provider: mockUser.provider,
+						user_external_identifier: mockUser.external_identifier,
+						user_auth_data: mockUser.auth_data,
+						user_role: mockUser.role,
+						share_id: null,
+						share_start: null,
+						share_end: null,
+					},
+				]);
+
+				tracker.on.delete('directus_sessions').responseOnce(1);
+
+				await expect(service.refresh(refreshToken)).rejects.toBeInstanceOf(UserSuspendedError);
+
+				expect(tracker.history.delete[0]?.sql).toMatch(/directus_sessions/);
+				expect(tracker.history.delete[0]?.bindings).toContain(refreshToken);
+				expect(stall).toHaveBeenCalled();
+			});
+
+			it('should delete session, stall, and throw InvalidCredentialsError when user has other non-active status', async () => {
+				const refreshToken = 'old-refresh-token';
+
+				tracker.on.select('directus_sessions').responseOnce([
+					{
+						session_expires: new Date(Date.now() + 60_000),
+						session_next_token: null,
+						user_id: mockUser.id,
+						user_first_name: mockUser.first_name,
+						user_last_name: mockUser.last_name,
+						user_email: mockUser.email,
+						user_password: mockUser.password,
+						user_status: 'archived',
+						user_provider: mockUser.provider,
+						user_external_identifier: mockUser.external_identifier,
+						user_auth_data: mockUser.auth_data,
+						user_role: mockUser.role,
+						share_id: null,
+						share_start: null,
+						share_end: null,
+					},
+				]);
+
+				tracker.on.delete('directus_sessions').responseOnce(1);
+
+				await expect(service.refresh(refreshToken)).rejects.toBeInstanceOf(InvalidCredentialsError);
+
+				expect(tracker.history.delete[0]?.sql).toMatch(/directus_sessions/);
+				expect(tracker.history.delete[0]?.bindings).toContain(refreshToken);
+				expect(stall).toHaveBeenCalled();
 			});
 		});
 	});

--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -5,6 +5,7 @@ import {
 	InvalidCredentialsError,
 	InvalidOtpError,
 	ServiceUnavailableError,
+	UserDeactivatedError,
 	UserSuspendedError,
 } from '@directus/errors';
 import type { AbstractServiceOptions, Accountability, LoginResult, SchemaOverview } from '@directus/types';
@@ -361,6 +362,9 @@ export class AuthenticationService {
 			if (record.user_status === 'suspended') {
 				await stall(STALL_TIME, timeStart);
 				throw new UserSuspendedError();
+			} else if (record.user_status === 'deactivated') {
+				await stall(STALL_TIME, timeStart);
+				throw new UserDeactivatedError();
 			} else {
 				await stall(STALL_TIME, timeStart);
 				throw new InvalidCredentialsError();

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -5,13 +5,26 @@ import { UserIntegrityCheckFlag } from '@directus/types';
 import knex from 'knex';
 import { createTracker, MockClient } from 'knex-mock-client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as license from '../license/index.js';
 import { validateRemainingAdminUsers } from '../permissions/modules/validate-remaining-admin/validate-remaining-admin-users.js';
 import { ItemsService, MailService, UsersService } from './index.js';
 
-vi.mock('../../src/database/index', () => ({
-	default: vi.fn(),
-	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
-}));
+vi.mock('../../src/database/index', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../../src/database/index.js')>();
+
+	const fakeKnex = {
+		select: vi.fn().mockReturnThis(),
+		from: vi.fn().mockReturnThis(),
+		first: vi.fn().mockResolvedValue({}),
+	};
+
+	return {
+		...actual,
+		getDatabaseClient: vi.fn().mockReturnValue('postgres'),
+		getSchemaInspector: vi.fn(),
+		getDatabase: vi.fn().mockReturnValue(fakeKnex),
+	};
+});
 
 vi.mock('./mail', () => {
 	const MailService = vi.fn();
@@ -437,6 +450,66 @@ describe('Integration Tests', () => {
 
 				expect(superUpdateManySpy.mock.lastCall![0]).toEqual([mockUser.id]);
 				expect(superUpdateManySpy.mock.lastCall![1]).toEqual({ role: 'invite-role' });
+			});
+		});
+
+		describe('checkAddingLimit', () => {
+			it('returns true when there is no users feature limit configured', async () => {
+				tracker.on.select('directus_users').responseOnce([{ count: '3' }]);
+
+				vi.spyOn(license, 'getFeature').mockResolvedValueOnce(undefined as any);
+
+				const result = await service.checkAddingLimit(10);
+
+				expect(result).toBe(true);
+			});
+
+			it('returns true when current active users plus count is within the limit', async () => {
+				tracker.on.select('directus_users').responseOnce([{ count: '2' }]);
+
+				vi.spyOn(license, 'getFeature').mockResolvedValueOnce({ limit: 5 } as any);
+
+				const result = await service.checkAddingLimit(2);
+
+				// 2 existing + 2 new = 4 <= 5
+				expect(result).toBe(true);
+			});
+
+			it('returns false when current active users plus count exceeds the limit', async () => {
+				tracker.on.select('directus_users').responseOnce([{ count: '4' }]);
+
+				vi.spyOn(license, 'getFeature').mockResolvedValueOnce({ limit: 5 } as any);
+
+				const result = await service.checkAddingLimit(2);
+
+				// 4 existing + 2 new = 6 > 5
+				expect(result).toBe(false);
+			});
+		});
+
+		describe('isActive', () => {
+			it('returns true when user status is active', async () => {
+				tracker.on.select('directus_users').responseOnce([{ status: 'active' }]);
+
+				const result = await service.isActive('user-id-active');
+
+				expect(result).toBe(true);
+			});
+
+			it('returns false when user status is not active', async () => {
+				tracker.on.select('directus_users').responseOnce([{ status: 'suspended' }]);
+
+				const result = await service.isActive('user-id-suspended');
+
+				expect(result).toBe(false);
+			});
+
+			it('returns false when user does not exist', async () => {
+				tracker.on.select('directus_users').responseOnce([]);
+
+				const result = await service.isActive('non-existent-id');
+
+				expect(result).toBe(false);
 			});
 		});
 	});

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -19,6 +19,7 @@ import type { StringValue } from 'ms';
 import { clearSystemCache } from '../cache.js';
 import { DEFAULT_AUTH_PROVIDER } from '../constants.js';
 import getDatabase from '../database/index.js';
+import { getFeature } from '../license/index.js';
 import { useLogger } from '../logger/index.js';
 import { validateRemainingAdminUsers } from '../permissions/modules/validate-remaining-admin/validate-remaining-admin-users.js';
 import { createDefaultAccountability } from '../permissions/utils/create-default-accountability.js';
@@ -653,5 +654,34 @@ export class UsersService extends ItemsService {
 		if (this.cache && opts?.autoPurgeCache !== false) {
 			await this.cache.clear();
 		}
+	}
+
+	/**
+	 * Verify if adding new active users is within the limit.
+	 */
+	async checkAddingLimit(count: number): Promise<boolean> {
+		const usersCountResult = await this.knex('directus_users').where('status', 'active').count<{ count: string }[]>({
+			count: '*',
+		});
+
+		const usersCount = Number(usersCountResult[0]?.count ?? 0);
+
+		const usersFeature = await getFeature<{ limit?: number }>('users');
+		const usersLimit = usersFeature?.limit;
+
+		if (usersLimit && usersCount + count > usersLimit) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check if a user is active by id
+	 */
+	async isActive(userId: PrimaryKey): Promise<boolean> {
+		const user = await this.knex.select('status').from('directus_users').where({ id: userId }).first();
+
+		return user?.status === 'active';
 	}
 }

--- a/api/src/types/auth.ts
+++ b/api/src/types/auth.ts
@@ -10,7 +10,7 @@ export interface User {
 	last_name: string | null;
 	email: string | null;
 	password: string | null;
-	status: 'active' | 'suspended' | 'invited';
+	status: 'active' | 'suspended' | 'invited' | 'deactivated';
 	role: string | null;
 	provider: string;
 	external_identifier: string | null;

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -99,6 +99,7 @@ settings_license_deactivation_popup_notice_and: ' and '
 settings_license_deactivate_confirm:
   Are you sure you want to deactivate the license? This will remove the license from this project.
 settings_license_deactivate_success: License deactivated successfully
+user_status_deactivated: Deactivated
 error_archiving_users: Failed to deactivate selected users.
 error_excluding_collections: Failed to deactivate selected collections.
 license_valid: License Valid
@@ -1603,6 +1604,7 @@ fields:
     status_active: Active
     status_suspended: Suspended
     status_archived: Archived
+    status_deactivated: Deactivated
     role: Role
     token: Token
     provider: Provider

--- a/app/src/modules/settings/routes/license/components/deactivation-popup.vue
+++ b/app/src/modules/settings/routes/license/components/deactivation-popup.vue
@@ -152,7 +152,7 @@ async function archiveUsers(userIds: string[]) {
 	try {
 		const response = await api.patch(
 			'/users',
-			userIds.map((id) => ({ id, status: 'archived' })),
+			userIds.map((id) => ({ id, status: 'deactivated' })),
 		);
 
 		return response?.data?.data;

--- a/app/src/views/private/components/user-popover.vue
+++ b/app/src/views/private/components/user-popover.vue
@@ -149,6 +149,10 @@ function navigateToUser() {
 			--v-chip-color: var(--theme--danger);
 			--v-chip-background-color: var(--danger-25);
 		}
+		&.deactivated {
+			--v-chip-color: var(--theme--foreground-accent);
+			--v-chip-background-color: var(--theme--background-accent);
+		}
 	}
 
 	.email {

--- a/packages/errors/src/codes.ts
+++ b/packages/errors/src/codes.ts
@@ -31,6 +31,7 @@ export enum ErrorCode {
 	UnexpectedResponse = 'UNEXPECTED_RESPONSE',
 	UnprocessableContent = 'UNPROCESSABLE_CONTENT',
 	UnsupportedMediaType = 'UNSUPPORTED_MEDIA_TYPE',
+	UserDeactivated = 'USER_DEACTIVATED',
 	UserSuspended = 'USER_SUSPENDED',
 	ValueOutOfRange = 'VALUE_OUT_OF_RANGE',
 	ValueTooLong = 'VALUE_TOO_LONG',

--- a/packages/errors/src/errors/index.ts
+++ b/packages/errors/src/errors/index.ts
@@ -30,6 +30,7 @@ export { TokenExpiredError } from './token-expired.js';
 export { UnexpectedResponseError } from './unexpected-response.js';
 export { UnprocessableContentError } from './unprocessable-content.js';
 export { UnsupportedMediaTypeError } from './unsupported-media-type.js';
+export { UserDeactivatedError } from './user-deactivated.js';
 export { UserSuspendedError } from './user-suspended.js';
 export { ValueOutOfRangeError } from './value-out-of-range.js';
 export { ValueTooLongError } from './value-too-long.js';

--- a/packages/errors/src/errors/user-deactivated.ts
+++ b/packages/errors/src/errors/user-deactivated.ts
@@ -1,0 +1,3 @@
+import { createError, ErrorCode } from '../index.js';
+
+export const UserDeactivatedError = createError(ErrorCode.UserDeactivated, 'User deactivated.', 401);

--- a/packages/system-data/src/fields/users.yaml
+++ b/packages/system-data/src/fields/users.yaml
@@ -183,6 +183,8 @@ fields:
           value: suspended
         - text: $t:fields.directus_users.status_archived
           value: archived
+        - text: $t:fields.directus_users.status_deactivated
+          value: deactivated
     width: half
 
   - field: role

--- a/packages/types/src/users.ts
+++ b/packages/types/src/users.ts
@@ -16,7 +16,7 @@ export type Avatar = {
 
 export type User = {
 	id: string;
-	status: 'draft' | 'invited' | 'unverified' | 'active' | 'suspended' | 'archived';
+	status: 'draft' | 'invited' | 'unverified' | 'active' | 'suspended' | 'archived' | 'deactivated';
 	first_name: string | null;
 	last_name: string | null;
 	email: string | null;


### PR DESCRIPTION
## Scope

<img width="1646" height="625" alt="image" src="https://github.com/user-attachments/assets/1b33013b-3bdd-4f03-bd6d-8fc8200d1252" />

<img width="1643" height="944" alt="Screenshot 2026-03-19 at 21 23 59" src="https://github.com/user-attachments/assets/02f02dc7-e61b-4938-bebd-7b7191159d24" />

What's changed:
- Introduce user `deactivated` status
- Handle deactivated user UI 
- Limit checking when create user, update user(s) status, send user invite, register

## Potential Risks / Drawbacks
- N/A

## Tested Scenarios
- N/A

## Review Notes / Questions
- N/A

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #\<num\>
