### PR TITLE
DIR-54-Fix : excluded collection row UX and license upgrade button

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -267,6 +267,7 @@ edit_collection: Edit Collection
 exclusive: Exclusive
 children: Children
 db_only_click_to_configure: 'Database Only: Click to Configure'
+excluded_click_to_configure: 'Excluded: Click to Configure'
 show_active_items: Show Active Items
 show_archived_items: Show Archived Items
 show_all_items: Show All Items

--- a/app/src/modules/settings/routes/data-model/collections/collections.vue
+++ b/app/src/modules/settings/routes/data-model/collections/collections.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { saveAs } from 'file-saver';
-import { merge } from 'lodash';
+import { merge, orderBy } from 'lodash';
 import { computed, ref } from 'vue';
 import { RouterLink, RouterView, useRouter } from 'vue-router';
 import Draggable from 'vuedraggable';
@@ -69,7 +69,9 @@ const approachingCollectionsLimit = computed(
 );
 
 const rootCollections = computed(() => {
-	return collections.value.filter((collection) => !collection.meta?.group);
+	const roots = collections.value.filter((collection) => !collection.meta?.group);
+
+	return orderBy(roots, [(c) => (c.meta?.excluded === true ? 1 : 0), 'meta.sort', 'collection']);
 });
 
 export type CollectionTree = {

--- a/app/src/modules/settings/routes/data-model/collections/components/CollectionItem.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/CollectionItem.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { orderBy } from 'lodash';
 import { computed } from 'vue';
 import Draggable from 'vuedraggable';
 import { CollectionTree } from '../collections.vue';
@@ -26,9 +27,15 @@ const toggleCollapse = () => {
 	emit('toggleCollapse', props.collection.collection);
 };
 
-const nestedCollections = computed(() =>
-	props.collections.filter((collection) => collection.meta?.group === props.collection.collection),
-);
+const nestedCollections = computed(() => {
+	const nested = props.collections.filter((collection) => collection.meta?.group === props.collection.collection);
+
+	return orderBy(nested, [
+		(c) => ((c.meta as { excluded?: boolean } | null)?.excluded === true ? 1 : 0),
+		'meta.sort',
+		'collection',
+	]);
+});
 
 function onGroupSortChange(collections: Collection[]) {
 	const updates = collections.map((collection) => ({

--- a/app/src/modules/settings/routes/data-model/collections/components/CollectionItem.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/CollectionItem.vue
@@ -40,26 +40,32 @@ function onGroupSortChange(collections: Collection[]) {
 
 	emit('setNestedSort', updates);
 }
+
+function onListItemClick() {
+	if (isExcluded.value) {
+		emit('unExclude', props.collection.collection);
+		return;
+	}
+
+	if (!props.collection.schema) {
+		emit('editCollection', props.collection);
+	}
+}
 </script>
 
 <template>
 	<div v-show="visibilityTree.visible" class="collection-item">
 		<VListItem
+			v-tooltip="isExcluded ? $t('excluded_click_to_configure') : undefined"
 			block
 			dense
 			clickable
 			:class="{ hidden: collection.meta?.hidden, excluded: isExcluded }"
 			:to="collection.schema && !isExcluded ? `/settings/data-model/${collection.collection}` : undefined"
-			@click.self="!collection.schema ? $emit('editCollection', collection) : null"
+			@click="onListItemClick"
 		>
 			<VListItemIcon>
-				<VIcon
-					v-if="isExcluded"
-					v-tooltip="$t('un_exclude_collection')"
-					name="add"
-					clickable
-					@click.stop="$emit('unExclude', collection.collection)"
-				/>
+				<VIcon v-if="isExcluded" name="add" />
 				<VIcon v-else-if="!disableDrag" class="drag-handle" name="drag_handle" />
 			</VListItemIcon>
 			<div class="collection-item-detail">

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
@@ -87,7 +87,7 @@ async function update(updates: DeepPartial<Collection>) {
 	<div v-if="isSystemCollection(collection.collection) === false || collection.meta?.excluded">
 		<VMenu placement="left-start" show-arrow>
 			<template #activator="{ toggle }">
-				<VIcon name="more_vert" clickable class="ctx-toggle" @click.prevent="toggle" />
+				<VIcon name="more_vert" clickable class="ctx-toggle" @click.stop.prevent="toggle" />
 			</template>
 			<VList>
 				<VListItem v-if="collection.meta?.excluded" clickable @click="emit('unExclude', collection.collection)">

--- a/app/src/modules/settings/routes/license/components/license-addons-section.vue
+++ b/app/src/modules/settings/routes/license/components/license-addons-section.vue
@@ -63,14 +63,7 @@ defineProps<{
 						<VIcon name="add_shopping_cart" class="add-on-purchase-icon" />
 						{{ $t('settings_license_purchase') }}
 					</VButton>
-					<VButton
-						v-else-if="pkg.showUpgradePlan"
-						secondary
-						small
-						class="add-on-upgrade-btn"
-						:href="`https://directus.io/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2025_10_kyc&utm_term=${version}&utm_content=settings_addon_upgrade_${pkg.id}`"
-						target="_blank"
-					>
+					<VButton v-else-if="pkg.showUpgradePlan" secondary small class="add-on-upgrade-btn" disabled>
 						<VIcon name="diamond" class="add-on-upgrade-icon" />
 						{{ $t('settings_license_upgrade_plan') }}
 					</VButton>
@@ -187,6 +180,10 @@ defineProps<{
 	flex-shrink: 0;
 
 	--v-button-color: var(--theme--foreground-subdued);
+}
+
+.add-on-upgrade-btn :deep(.button:disabled) {
+	cursor: default;
 }
 
 .add-on-upgrade-icon {


### PR DESCRIPTION
## Scope

What's changed:

- Ordered root and nested collections so excluded collections appear after non-excluded ones (`orderBy` on `meta.excluded`, then `meta.sort`, then name).
- Added English string `excluded_click_to_configure` for excluded collections in the data model list.
- Updated `CollectionItem.vue` so excluded collections show a row tooltip, the whole row click un-excludes, and the add icon no longer carries its own tooltip/click handler.
- Updated `collection-options.vue` so the overflow menu activator uses `@click.stop` to avoid event bubbling issues.
- Replaced the license add-on "Upgrade plan" external link with a disabled `VButton` and added disabled cursor styling in `license-addons-section.vue`.

## Potential Risks / Drawbacks

N/A

## Tested Scenarios

N/A

## Review Notes / Questions

N/A

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

## Screen Shot

<img width="1779" height="967" alt="image" src="https://github.com/user-attachments/assets/52493d35-7e59-4be8-918b-c57912ab0bc3" />
<img width="1766" height="970" alt="image" src="https://github.com/user-attachments/assets/e6a451fe-1ce7-407e-9116-26fd1ea0b917" />

---

Fixes #\<num\>
