### PR TITLE
feat: update license setting page behavior when license key provide in env

### DIFF
--- a/app/src/interfaces/presentation-license-section/presentation-license-section.vue
+++ b/app/src/interfaces/presentation-license-section/presentation-license-section.vue
@@ -67,6 +67,7 @@ const onConfirmDeactivate = inject<() => void>('license:onConfirmDeactivate', ()
 			v-else-if="section === 'danger' && value"
 			:deactivating="value.deactivating ?? false"
 			:on-confirm-deactivate="onConfirmDeactivate"
+			:is-license-from-env="value.isLicenseFromEnv ?? false"
 		/>
 	</div>
 </template>

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -54,7 +54,7 @@ license_key_management_notice: Have a license key? Enter it below to activate yo
 settings_license_no_key: No license key configured
 settings_license_value_stored: Value Securely Stored
 settings_license_edit: Edit License Key
-settings_license_env_managed: Managed via environment variable
+settings_license_env_managed: You will need to manage your license key through your ENV.
 settings_license_add: Add License Key
 settings_license_manage: Manage License
 settings_license_upgrade_plan: Upgrade Plan

--- a/app/src/modules/settings/routes/license/components/license-banners-section.vue
+++ b/app/src/modules/settings/routes/license/components/license-banners-section.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { I18nT, useI18n } from 'vue-i18n';
 import VIcon from '@/components/v-icon/v-icon.vue';
-import VNotice from '@/components/v-notice.vue';
 
 defineProps<{
 	showExpiringSoonWarning: boolean;
@@ -57,10 +56,6 @@ const { t } = useI18n();
 				</div>
 				<span class="banner-text">{{ t('license_project_locked_notice') }}</span>
 			</div>
-		</div>
-
-		<div v-if="licenseSource === 'env'" class="env-managed-banner">
-			<VNotice type="info">{{ t('settings_license_env_managed') }}</VNotice>
 		</div>
 	</div>
 </template>
@@ -131,10 +126,5 @@ const { t } = useI18n();
 
 .license-grace-period-banner .banner-text strong {
 	font-weight: 600;
-}
-
-.env-managed-banner {
-	inline-size: 100%;
-	margin-block-end: 24px;
 }
 </style>

--- a/app/src/modules/settings/routes/license/components/license-danger-section.vue
+++ b/app/src/modules/settings/routes/license/components/license-danger-section.vue
@@ -2,10 +2,12 @@
 import { useI18n } from 'vue-i18n';
 import VButton from '@/components/v-button.vue';
 import VIcon from '@/components/v-icon/v-icon.vue';
+import VNotice from '@/components/v-notice.vue';
 
 defineProps<{
 	deactivating: boolean;
 	onConfirmDeactivate: () => void;
+	isLicenseFromEnv: boolean;
 }>();
 
 const { t } = useI18n();
@@ -17,9 +19,20 @@ const { t } = useI18n();
 			<VIcon name="emergency_home" class="danger-zone-icon" />
 			<h3 class="danger-zone-title">{{ t('settings_license_danger_zone') }}</h3>
 		</div>
+
 		<div class="danger-zone-separator" />
+
+		<div v-if="isLicenseFromEnv" class="danger-zone-banner">
+			<VNotice type="info">{{ t('settings_license_env_managed') }}</VNotice>
+		</div>
+
 		<div class="danger-zone-content">
-			<VButton kind="danger" :loading="deactivating" :disabled="deactivating" @click="onConfirmDeactivate">
+			<VButton
+				kind="danger"
+				:loading="deactivating"
+				:disabled="isLicenseFromEnv || deactivating"
+				@click="onConfirmDeactivate"
+			>
 				{{ t('settings_license_deactivate') }}
 			</VButton>
 		</div>
@@ -58,8 +71,11 @@ const { t } = useI18n();
 }
 
 .danger-zone-content {
-	padding-block-start: 20px;
 	display: grid;
 	gap: 16px;
+}
+
+.danger-zone-banner {
+	margin-block: 2.25rem;
 }
 </style>

--- a/app/src/modules/settings/routes/license/components/license-plan-section.vue
+++ b/app/src/modules/settings/routes/license/components/license-plan-section.vue
@@ -32,7 +32,7 @@ const { t } = useI18n();
 				</div>
 			</div>
 			<div class="plan-actions">
-				<VButton v-if="canManageLicense" secondary small class="plan-action-btn" @click="onOpenDrawer">
+				<VButton :disabled="!canManageLicense" secondary small class="plan-action-btn" @click="onOpenDrawer">
 					{{ addLicenseKeyLabel }}
 				</VButton>
 				<VButton

--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -111,8 +111,6 @@ const showExpiredBeyondGraceNotice = computed(
 
 const drawerPayload = computed(() => (savedSuccessfully.value ? info.value.license : null));
 
-const showDeactivateSection = computed(() => licenseSource.value === 'settings' && info.value.license != null);
-
 const canManageLicense = computed(() => licenseSource.value !== 'env');
 
 const addLicenseKeyLabel = computed(() =>
@@ -240,65 +238,58 @@ provide('license:onConfirmDeactivate', () => {
 	confirmDeactivate.value = true;
 });
 
-const licenseFormFields = computed<DeepPartial<Field>[]>(() => {
-	const items: DeepPartial<Field>[] = [
-		{
-			field: 'license_plan_section',
-			name: '',
-			type: 'alias',
-			meta: {
-				interface: 'presentation-license-section',
-				options: { section: 'plan' },
-				width: 'full',
-			},
+const licenseFormFields: DeepPartial<Field[]> = [
+	{
+		field: 'license_plan_section',
+		name: '',
+		type: 'alias',
+		meta: {
+			interface: 'presentation-license-section',
+			options: { section: 'plan' },
+			width: 'full',
 		},
-		{
-			field: 'license_banners_section',
-			name: '',
-			type: 'alias',
-			meta: {
-				interface: 'presentation-license-section',
-				options: { section: 'banners' },
-				width: 'full',
-			},
+	},
+	{
+		field: 'license_banners_section',
+		name: '',
+		type: 'alias',
+		meta: {
+			interface: 'presentation-license-section',
+			options: { section: 'banners' },
+			width: 'full',
 		},
-		{
-			field: 'license_usage_section',
-			name: '',
-			type: 'alias',
-			meta: {
-				interface: 'presentation-license-section',
-				options: { section: 'usage' },
-				width: 'full',
-			},
+	},
+	{
+		field: 'license_usage_section',
+		name: '',
+		type: 'alias',
+		meta: {
+			interface: 'presentation-license-section',
+			options: { section: 'usage' },
+			width: 'full',
 		},
-		{
-			field: 'license_addons_section',
-			name: '',
-			type: 'alias',
-			meta: {
-				interface: 'presentation-license-section',
-				options: { section: 'addons' },
-				width: 'full',
-			},
+	},
+	{
+		field: 'license_addons_section',
+		name: '',
+		type: 'alias',
+		meta: {
+			interface: 'presentation-license-section',
+			options: { section: 'addons' },
+			width: 'full',
 		},
-	];
-
-	if (showDeactivateSection.value) {
-		items.push({
-			field: 'license_danger_section',
-			name: '',
-			type: 'alias',
-			meta: {
-				interface: 'presentation-license-section',
-				options: { section: 'danger' },
-				width: 'full',
-			},
-		});
-	}
-
-	return items;
-});
+	},
+	{
+		field: 'license_danger_section',
+		name: '',
+		type: 'alias',
+		meta: {
+			interface: 'presentation-license-section',
+			options: { section: 'danger' },
+			width: 'full',
+		},
+	},
+];
 
 const licenseFormValues = computed(() => ({
 	license_plan_section: {
@@ -335,6 +326,7 @@ const licenseFormValues = computed(() => ({
 	},
 	license_danger_section: {
 		deactivating: deactivating.value,
+		isLicenseFromEnv: licenseSource.value === 'env',
 	},
 }));
 
@@ -502,22 +494,6 @@ const licenseFormEdits = ref<Record<string, any> | null>(null);
 
 .drawer-info-banner {
 	margin-block-end: 0;
-}
-
-.drawer-info-row {
-	display: flex;
-	align-items: flex-start;
-	gap: 12px;
-	font-size: 14px;
-	line-height: 22px;
-	color: var(--theme--foreground);
-}
-
-.drawer-info-icon {
-	--v-icon-color: var(--theme--primary);
-	--v-icon-size: 20px;
-	flex-shrink: 0;
-	margin-block-start: 1px;
 }
 
 .drawer-info-banner a {


### PR DESCRIPTION
What's changed:
- Unhide "Manage License" button in License Setting Page
- Disable "Manage License" button when License Key is from Env
- Disable "Deactivate License" button when License Key is from Env
- Add new VNotice for notifying the License is managed from ENV
- Update FormFields from license.vue to Array instead of ComputedArray