### PR TITLE
feat: implement purchase addon modals

### DIFF
--- a/api/src/license/addons.ts
+++ b/api/src/license/addons.ts
@@ -5,12 +5,7 @@
 
 export interface LicenseAddon {
 	id: string;
-	name: string;
-	description: string;
-	status: 'available' | 'purchased';
-	action: 'purchase' | 'info';
-	icon?: string;
-	disabled?: boolean;
+	quantity?: number; // numeric addons only (e.g. user_seats, collections)
 }
 
 export interface LicenseAddonsResponse {
@@ -18,48 +13,16 @@ export interface LicenseAddonsResponse {
 }
 
 /**
- * Returns mocked add-on packages metadata.
+ * Returns purchased add-on IDs with optional quantity for numeric addons.
+ * Boolean addons (e.g. sso) are represented by presence alone.
  * TODO: Replace with real licensing service API call.
  */
 export async function getLicenseAddons(): Promise<LicenseAddonsResponse> {
+	// Example of a list of no purchased add-ons
+	// return { addons: [] };
+
+	// Example of a list of purchased add-ons with quantities
 	return {
-		addons: [
-			{
-				id: 'user_seats',
-				name: 'User Seats',
-				description: '$15.00 per seat',
-				status: 'available',
-				action: 'purchase',
-				icon: 'group',
-				disabled: false,
-			},
-			{
-				id: 'sso',
-				name: 'SSO Feature',
-				description: 'Allows SSO configuration',
-				status: 'available',
-				action: 'purchase',
-				icon: 'cloud_lock',
-				disabled: false,
-			},
-			{
-				id: 'collections',
-				name: 'Data Model Collections',
-				description: 'Additional collections',
-				status: 'available',
-				action: 'purchase',
-				icon: 'inventory_2',
-				disabled: true,
-			},
-			{
-				id: 'basic_support',
-				name: 'Basic Support',
-				description: '',
-				status: 'available',
-				action: 'purchase',
-				icon: 'support_agent',
-				disabled: true,
-			},
-		],
+		addons: [{ id: 'user_seats', quantity: 2 }, { id: 'collections', quantity: 1 }, { id: 'sso' }],
 	};
 }

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -100,6 +100,11 @@ settings_license_deactivation_popup_remaining: '{count} remaining'
 settings_license_deactivation_popup_limit_count_success: 'All set'
 settings_license_deactivate_confirm: Are you sure you want to deactivate these collections and user seats?
 settings_license_deactivate_success: License deactivated successfully
+settings_license_addon_user_seats_title: Purchase Additional User Seats
+settings_license_addon_collections_title: Additional Collections Pack(s)
+settings_license_addon_collections_helper_text: 1 Pack = 25 Collections
+settings_license_addon_sso_title: Are you sure you want to purchase SSO feature?
+settings_license_addon_basic_support_title: Are you sure you want to purchase Basic Support feature?
 user_status_deactivated: Deactivated
 error_archiving_users: Failed to deactivate selected users.
 error_excluding_collections: Failed to deactivate selected collections.

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -56,7 +56,7 @@ settings_license_value_stored: Value Securely Stored
 settings_license_edit: Edit License Key
 settings_license_env_managed: Managed via environment variable
 settings_license_add: Add License Key
-settings_license_manage: Manage License
+settings_license_manage: Manage
 settings_license_upgrade_plan: Upgrade Plan
 settings_license_manage_plan: Manage Plan
 settings_license_current_plan: Current Plan
@@ -65,6 +65,7 @@ settings_license_your_plan_usage: Your Plan Usage
 settings_license_add_on_packages: Add-on Packages
 settings_license_add_on_info: Learn more about this add-on
 settings_license_purchase: Purchase
+settings_license_manage_addon: Manage
 settings_license_usage_available: Included
 settings_license_usage_unavailable: Not Included
 settings_license_usage_disabled: Disabled
@@ -100,11 +101,20 @@ settings_license_deactivation_popup_remaining: '{count} remaining'
 settings_license_deactivation_popup_limit_count_success: 'All set'
 settings_license_deactivate_confirm: Are you sure you want to deactivate these collections and user seats?
 settings_license_deactivate_success: License deactivated successfully
+settings_license_addon_user_seats_name: User Seats
+settings_license_addon_user_seats_description: '$15.00 per seat'
 settings_license_addon_user_seats_title: Purchase Additional User Seats
+settings_license_addon_user_seats_helper_text: 1 Pack = 10 Users
+settings_license_addon_sso_name: SSO Feature
+settings_license_addon_sso_description: Allows SSO configuration
+settings_license_addon_sso_title: Are you sure you want to purchase SSO feature?
+settings_license_addon_collections_name: Data Model Collections
+settings_license_addon_collections_description: '$100.00 per 25 collections/ pack'
 settings_license_addon_collections_title: Additional Collections Pack(s)
 settings_license_addon_collections_helper_text: 1 Pack = 25 Collections
-settings_license_addon_sso_title: Are you sure you want to purchase SSO feature?
+settings_license_addon_basic_support_name: Basic Support
 settings_license_addon_basic_support_title: Are you sure you want to purchase Basic Support feature?
+settings_license_addon_confirm_purchase: Confirm Purchase
 user_status_deactivated: Deactivated
 error_archiving_users: Failed to deactivate selected users.
 error_excluding_collections: Failed to deactivate selected collections.

--- a/app/src/modules/settings/routes/license/components/license-addons-section.vue
+++ b/app/src/modules/settings/routes/license/components/license-addons-section.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { ref } from 'vue';
+import PurchaseAddonModal from './purchase-addon-modal.vue';
 import VButton from '@/components/v-button.vue';
 import VIcon from '@/components/v-icon/v-icon.vue';
 import VNotice from '@/components/v-notice.vue';
@@ -23,6 +25,16 @@ defineProps<{
 	addonsError: string | null;
 	version: string;
 }>();
+
+const showPurchaseModal = ref(false);
+const selectedAddonInfo = ref<string | null>(null);
+
+function openPurchaseModal(addon: Addon) {
+	if (addon.id) {
+		selectedAddonInfo.value = addon.id;
+		showPurchaseModal.value = true;
+	}
+}
 </script>
 
 <template>
@@ -52,14 +64,7 @@ defineProps<{
 							{{ pkg.description }}
 						</span>
 					</div>
-					<VButton
-						v-if="pkg.showPurchase"
-						secondary
-						small
-						class="add-on-purchase-btn"
-						:href="`https://directus.io/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2025_10_kyc&utm_term=${version}&utm_content=settings_addon_${pkg.id}`"
-						target="_blank"
-					>
+					<VButton v-if="pkg.showPurchase" secondary small class="add-on-purchase-btn" @click="openPurchaseModal(pkg)">
 						<VIcon name="add_shopping_cart" class="add-on-purchase-icon" />
 						{{ $t('settings_license_purchase') }}
 					</VButton>
@@ -77,6 +82,8 @@ defineProps<{
 			</template>
 		</div>
 	</div>
+
+	<PurchaseAddonModal v-if="selectedAddonInfo" v-model="showPurchaseModal" :addon-id="selectedAddonInfo" />
 </template>
 
 <style scoped>

--- a/app/src/modules/settings/routes/license/components/license-addons-section.vue
+++ b/app/src/modules/settings/routes/license/components/license-addons-section.vue
@@ -10,13 +10,11 @@ type Addon = {
 	id: string;
 	name: string;
 	description: string;
-	status: string;
-	action: string;
 	icon: string;
+	disabled: boolean;
 	showPurchase: boolean;
-	showInfo: boolean;
-	disabled?: boolean;
-	showUpgradePlan?: boolean;
+	showManage: boolean;
+	showUpgradePlan: boolean;
 };
 
 defineProps<{
@@ -53,31 +51,32 @@ function openPurchaseModal(addon: Addon) {
 			</VNotice>
 			<template v-else>
 				<div v-for="pkg in addons" :key="pkg.id" class="add-on-card" :class="{ disabled: pkg.disabled }">
-					<div class="add-on-icon-wrapper" :class="{ disabled: pkg.disabled }">
+					<div class="add-on-icon-wrapper">
 						<VIcon :name="pkg.icon" class="add-on-icon" />
 					</div>
 					<div class="add-on-content">
-						<span class="add-on-title" :class="{ disabled: pkg.disabled }">
-							{{ pkg.name }}
-						</span>
-						<span v-if="pkg.description" class="add-on-description" :class="{ disabled: pkg.disabled }">
-							{{ pkg.description }}
-						</span>
+						<span class="add-on-title">{{ pkg.name }}</span>
+						<span v-if="pkg.description" class="add-on-description">{{ pkg.description }}</span>
 					</div>
-					<VButton v-if="pkg.showPurchase" secondary small class="add-on-purchase-btn" @click="openPurchaseModal(pkg)">
+					<VButton
+						v-if="pkg.showPurchase"
+						secondary
+						small
+						class="add-on-purchase-btn"
+						:disabled="pkg.disabled"
+						@click="openPurchaseModal(pkg)"
+					>
 						<VIcon name="add_shopping_cart" class="add-on-purchase-icon" />
 						{{ $t('settings_license_purchase') }}
 					</VButton>
-					<VButton v-else-if="pkg.showUpgradePlan" secondary small class="add-on-upgrade-btn" disabled>
+					<VButton v-else-if="pkg.showManage" secondary small class="add-on-manage-btn" :disabled="pkg.disabled">
+						<VIcon name="settings" class="add-on-manage-icon" />
+						{{ $t('settings_license_manage_addon') }}
+					</VButton>
+					<VButton v-else-if="pkg.showUpgradePlan" secondary small class="add-on-upgrade-btn" :disabled="pkg.disabled">
 						<VIcon name="diamond" class="add-on-upgrade-icon" />
 						{{ $t('settings_license_upgrade_plan') }}
 					</VButton>
-					<VIcon
-						v-else-if="pkg.showInfo"
-						v-tooltip.bottom="$t('settings_license_add_on_info')"
-						name="info"
-						class="add-on-info-icon"
-					/>
 				</div>
 			</template>
 		</div>
@@ -125,12 +124,22 @@ function openPurchaseModal(addon: Addon) {
 }
 
 .add-on-card {
+	--add-on-card-background: var(--theme--background-normal);
 	display: flex;
 	align-items: center;
 	gap: 16px;
 	padding: 16px 20px;
-	background: var(--theme--background-subdued);
+	background: var(--add-on-card-background);
 	border-radius: 8px;
+
+	--v-addon-icon-background: var(--theme--primary);
+	--addon-title-color: var(--theme--foreground);
+
+	&.disabled {
+		--v-addon-icon-background: var(--theme--foreground-subdued);
+		--add-on-card-background: var(--theme--background-subdued);
+		--addon-title-color: var(--theme--foreground-subdued);
+	}
 }
 
 .add-on-icon-wrapper {
@@ -140,27 +149,13 @@ function openPurchaseModal(addon: Addon) {
 	inline-size: 40px;
 	block-size: 40px;
 	border-radius: 50%;
-	background: var(--theme--primary);
+	background: var(--v-addon-icon-background);
 	flex-shrink: 0;
-}
-
-.add-on-icon-wrapper.disabled {
-	background: var(--theme--background-normal);
-}
-
-.add-on-icon-wrapper.disabled .add-on-icon {
-	--v-icon-color: var(--theme--foreground-subdued);
 }
 
 .add-on-icon {
 	--v-icon-color: var(--white);
 	--v-icon-size: 22px;
-	flex-shrink: 0;
-}
-
-.add-on-info-icon {
-	--v-icon-color: var(--theme--foreground-subdued);
-	--v-icon-size: 18px;
 	flex-shrink: 0;
 }
 
@@ -173,11 +168,23 @@ function openPurchaseModal(addon: Addon) {
 }
 
 .add-on-purchase-btn {
+	--v-button-background-color: var(--theme--background-accent);
 	white-space: nowrap;
 	flex-shrink: 0;
 }
 
 .add-on-purchase-icon {
+	--v-icon-size: 18px;
+	margin-inline-end: 6px;
+}
+
+.add-on-manage-btn {
+	--v-button-background-color: var(--theme--background-accent);
+	white-space: nowrap;
+	flex-shrink: 0;
+}
+
+.add-on-manage-icon {
 	--v-icon-size: 18px;
 	margin-inline-end: 6px;
 }
@@ -194,7 +201,6 @@ function openPurchaseModal(addon: Addon) {
 }
 
 .add-on-upgrade-icon {
-	--v-icon-color: var(--theme--foreground-subdued);
 	--v-icon-size: 18px;
 	margin-inline-end: 6px;
 }
@@ -202,20 +208,11 @@ function openPurchaseModal(addon: Addon) {
 .add-on-title {
 	font-size: 14px;
 	font-weight: 600;
-	color: var(--theme--foreground);
-}
-
-.add-on-title.disabled {
-	color: var(--theme--foreground-subdued);
+	color: var(--addon-title-color);
 }
 
 .add-on-description {
 	font-size: 13px;
 	color: var(--theme--foreground-subdued);
-}
-
-.add-on-description.disabled {
-	color: var(--theme--foreground-subdued);
-	opacity: 0.8;
 }
 </style>

--- a/app/src/modules/settings/routes/license/components/purchase-addon-modal.vue
+++ b/app/src/modules/settings/routes/license/components/purchase-addon-modal.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 import VButton from '@/components/v-button.vue';
@@ -48,9 +48,13 @@ const addonData: Record<string, AddonInfo> = {
 	basic_support: { title: t('settings_license_addon_basic_support_title'), type: 'boolean' },
 };
 
-const addonInfo = ref(props.addonId ? addonData[props.addonId] : undefined);
+const addonInfo = computed(() => addonData[props.addonId]);
 
 const quantity = ref(addonInfo.value?.type === 'numeric' ? (addonInfo.value?.min ?? 1) : 1);
+
+watch(addonInfo, (info) => {
+	quantity.value = info?.type === 'numeric' ? (info.min ?? 1) : 1;
+});
 
 function cancel() {
 	emit('update:modelValue', false);
@@ -100,8 +104,10 @@ function confirm() {
 			</template>
 
 			<VCardActions class="modal-actions">
-				<VButton secondary large class="cancel-btn" @click="cancel">Cancel</VButton>
-				<VButton large class="confirm-btn" @click="confirm">Confirm Purchase</VButton>
+				<VButton secondary large class="cancel-btn" @click="cancel">{{ $t('cancel') }}</VButton>
+				<VButton large class="confirm-btn" @click="confirm">
+					{{ $t('settings_license_addon_confirm_purchase') }}
+				</VButton>
 			</VCardActions>
 		</VCard>
 	</VDialog>

--- a/app/src/modules/settings/routes/license/components/purchase-addon-modal.vue
+++ b/app/src/modules/settings/routes/license/components/purchase-addon-modal.vue
@@ -1,0 +1,176 @@
+<script lang="ts" setup>
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
+import VButton from '@/components/v-button.vue';
+import VCardActions from '@/components/v-card-actions.vue';
+import VCardTitle from '@/components/v-card-title.vue';
+import VCard from '@/components/v-card.vue';
+import VDialog from '@/components/v-dialog.vue';
+import VIcon from '@/components/v-icon/v-icon.vue';
+import VInput from '@/components/v-input.vue';
+
+type AddonInfo = {
+	type: 'numeric' | 'boolean';
+	title: string;
+	min?: number;
+	max?: number;
+	helperText?: string;
+};
+
+const props = defineProps<{
+	addonId: string;
+	modelValue?: boolean;
+}>();
+
+const emit = defineEmits<{
+	'update:modelValue': [value: boolean];
+}>();
+
+const { t } = useI18n();
+const router = useRouter();
+
+const addonData: Record<string, AddonInfo> = {
+	user_seats: {
+		type: 'numeric',
+		title: t('settings_license_addon_user_seats_title'),
+		min: 1,
+		max: 10,
+	},
+	sso: { title: t('settings_license_addon_sso_title'), type: 'boolean' },
+	collections: {
+		title: t('settings_license_addon_collections_title'),
+		type: 'numeric',
+		min: 1,
+		max: 10,
+		helperText: t('settings_license_addon_collections_helper_text'),
+	},
+	basic_support: { title: t('settings_license_addon_basic_support_title'), type: 'boolean' },
+};
+
+const addonInfo = ref(props.addonId ? addonData[props.addonId] : undefined);
+
+const quantity = ref(addonInfo.value?.type === 'numeric' ? (addonInfo.value?.min ?? 1) : 1);
+
+function cancel() {
+	emit('update:modelValue', false);
+}
+
+function confirm() {
+	emit('update:modelValue', false);
+
+	//TODO: Update this when have more infor
+	router.push('https://directus.io/license-request');
+}
+</script>
+
+<template>
+	<VDialog :model-value="modelValue" @update:model-value="emit('update:modelValue', $event)">
+		<VCard class="purchase-addon-modal">
+			<!-- Boolean addon: confirmation message only -->
+			<template v-if="addonInfo?.type === 'boolean'">
+				<VCardTitle class="modal-title modal-title--confirm">{{ addonInfo.title }}</VCardTitle>
+			</template>
+
+			<!-- Numeric addon: title + quantity input -->
+			<template v-else>
+				<VCardTitle class="modal-title">
+					{{ addonInfo?.title ?? 'Additional Collections Pack(s)' }}
+				</VCardTitle>
+
+				<div class="modal-body">
+					<VInput
+						v-model="quantity"
+						type="number"
+						:min="addonInfo?.min ?? 1"
+						:max="addonInfo?.max"
+						:step="1"
+						integer
+						class="quantity-input"
+					>
+						<template #prepend>
+							<VIcon name="storage" class="input-icon" />
+						</template>
+					</VInput>
+
+					<p v-if="addonInfo?.helperText" class="helper-text">
+						{{ addonInfo?.helperText }}
+					</p>
+				</div>
+			</template>
+
+			<VCardActions class="modal-actions">
+				<VButton secondary large class="cancel-btn" @click="cancel">Cancel</VButton>
+				<VButton large class="confirm-btn" @click="confirm">Confirm Purchase</VButton>
+			</VCardActions>
+		</VCard>
+	</VDialog>
+</template>
+
+<style lang="scss" scoped>
+.purchase-addon-modal {
+	inline-size: 660px;
+	padding: 8px;
+}
+
+.modal-title {
+	font-size: 20px;
+	font-weight: 700;
+	color: var(--theme--foreground);
+	padding: 16px 16px 20px;
+
+	&--confirm {
+		padding-block-end: 32px;
+	}
+}
+
+.modal-body {
+	padding: 0 16px 16px;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.quantity-input {
+	:deep(.input) {
+		block-size: 64px;
+		border-radius: 12px;
+		border-color: var(--theme--border-color);
+	}
+
+	:deep(.prepend) {
+		padding-inline-start: 16px;
+	}
+}
+
+.input-icon {
+	color: var(--theme--primary-subdued);
+}
+
+.helper-text {
+	font-style: italic;
+	color: var(--theme--primary-subdued);
+	font-size: 14px;
+	margin: 0;
+	padding-inline-start: 4px;
+}
+
+.modal-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 12px;
+	padding: 16px;
+}
+
+.cancel-btn {
+	min-inline-size: 160px;
+}
+
+.confirm-btn {
+	min-inline-size: 220px;
+
+	--v-button-background-color: #4f46e5;
+	--v-button-background-color-hover: #4338ca;
+	--v-button-color: #fff;
+}
+</style>

--- a/app/src/modules/settings/routes/license/composables/use-addon-metadata.ts
+++ b/app/src/modules/settings/routes/license/composables/use-addon-metadata.ts
@@ -1,0 +1,41 @@
+import { useI18n } from 'vue-i18n';
+
+export type AddonMetadata = {
+	name: string;
+	description: string;
+	icon: string;
+	type: 'numeric' | 'boolean';
+	disabled?: boolean;
+};
+
+export function useAddonMetadata(): Record<string, AddonMetadata> {
+	const { t } = useI18n();
+
+	return {
+		user_seats: {
+			name: t('settings_license_addon_user_seats_name'),
+			description: t('settings_license_addon_user_seats_description'),
+			icon: 'group',
+			type: 'numeric',
+		},
+		collections: {
+			name: t('settings_license_addon_collections_name'),
+			description: t('settings_license_addon_collections_description'),
+			icon: 'deployed_code',
+			type: 'numeric',
+		},
+		sso: {
+			name: t('settings_license_addon_sso_name'),
+			description: t('settings_license_addon_sso_description'),
+			icon: 'cloud_lock',
+			type: 'boolean',
+		},
+		basic_support: {
+			name: t('settings_license_addon_basic_support_name'),
+			description: '',
+			icon: 'support_agent',
+			type: 'boolean',
+			disabled: true,
+		},
+	};
+}

--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -6,6 +6,7 @@ import { storeToRefs } from 'pinia';
 import { computed, provide, ref, watch } from 'vue';
 import { I18nT, useI18n } from 'vue-i18n';
 import SettingsNavigation from '../../components/navigation.vue';
+import { useAddonMetadata } from './composables/use-addon-metadata';
 import VBreadcrumb from '@/components/v-breadcrumb.vue';
 import VButton from '@/components/v-button.vue';
 import VDrawer from '@/components/v-drawer.vue';
@@ -213,26 +214,22 @@ function onLicenseKeyInput(v: string) {
 	};
 }
 
-function mapAddonToDisplay(item: {
-	id: string;
-	name: string;
-	description: string;
-	status: string;
-	action: string;
-	icon?: string;
-	disabled?: boolean;
-}) {
-	return {
-		...item,
-		icon: item.icon ?? 'extension',
-		disabled: item.disabled ?? false,
-		showPurchase: !(item.disabled ?? false) && item.action === 'purchase',
-		showInfo: item.action === 'info',
-		showUpgradePlan: item.disabled ?? false,
-	};
-}
+const addonMetadata = useAddonMetadata();
 
-const addonsData = computed(() => addons.value?.data?.map(mapAddonToDisplay) ?? []);
+const addonsData = computed(() => {
+	const purchasedIds = new Set((addons.value?.data ?? []).map((a: { id: string }) => a.id));
+
+	return Object.entries(addonMetadata).map(([id, meta]) => ({
+		id,
+		name: meta.name,
+		description: meta.description,
+		icon: meta.icon,
+		disabled: meta.disabled ?? false,
+		showPurchase: !meta.disabled && !purchasedIds.has(id),
+		showManage: !meta.disabled && purchasedIds.has(id),
+		showUpgradePlan: meta.disabled ?? false,
+	}));
+});
 
 provide('license:openDrawer', openDrawer);
 


### PR DESCRIPTION
What's changed:
- Implement different Inputs Modal for 2 types: numeric and boolean
- Handle behaviors when `/server/license/addon` response data for rendering
- Implement Template for rendering Addons