### PR TITLE
feat: handle custom_permissions for PermissionService

### DIFF
--- a/api/src/services/permissions.ts
+++ b/api/src/services/permissions.ts
@@ -11,6 +11,8 @@ import type {
 } from '@directus/types';
 import { uniq } from 'lodash-es';
 import { clearSystemCache } from '../cache.js';
+import { getFeature } from '../license/index.js';
+import { type CustomPermissionsEntitlements, Entitlements } from '../license/types/index.js';
 import { fetchPermissions } from '../permissions/lib/fetch-permissions.js';
 import { fetchPolicies } from '../permissions/lib/fetch-policies.js';
 import { withAppMinimalPermissions } from '../permissions/lib/with-app-minimal-permissions.js';
@@ -21,6 +23,21 @@ import { ItemsService } from './items.js';
 export class PermissionsService extends ItemsService {
 	constructor(options: AbstractServiceOptions) {
 		super('directus_permissions', options);
+	}
+
+	private isCustomPermission(data: Partial<Permission>): boolean {
+		if (data.permissions && Object.keys(data.permissions as object).length > 0) return true;
+		if (data.validation && Object.keys(data.validation as object).length > 0) return true;
+
+		return !!(data.fields && Array.isArray(data.fields) && !data.fields.includes('*'));
+	}
+
+	private async assertCustomPermissionsEnabled(payloads: Partial<Item> | Partial<Item>[]): Promise<void> {
+		const items = Array.isArray(payloads) ? payloads : [payloads];
+		if (!items.some((p) => this.isCustomPermission(p))) return;
+
+		const feature = await getFeature<CustomPermissionsEntitlements>(Entitlements.CUSTOM_PERMISSIONS);
+		if (!feature?.enabled) throw new ForbiddenError();
 	}
 
 	private async clearCaches(opts?: MutationOptions) {
@@ -34,10 +51,19 @@ export class PermissionsService extends ItemsService {
 	override async readByQuery(query: Query, opts?: QueryOptions): Promise<Partial<Item>[]> {
 		const result = (await super.readByQuery(query, opts)) as Permission[];
 
-		return withAppMinimalPermissions(this.accountability, result, query.filter);
+		const permissions = withAppMinimalPermissions(this.accountability, result, query.filter);
+
+		const feature = await getFeature<CustomPermissionsEntitlements>(Entitlements.CUSTOM_PERMISSIONS);
+
+		if (!feature?.enabled) {
+			return permissions.filter((p) => !this.isCustomPermission(p));
+		}
+
+		return permissions;
 	}
 
 	override async createOne(data: Partial<Item>, opts?: MutationOptions) {
+		await this.assertCustomPermissionsEnabled(data);
 		const res = await super.createOne(data, opts);
 
 		await this.clearCaches(opts);
@@ -46,6 +72,7 @@ export class PermissionsService extends ItemsService {
 	}
 
 	override async createMany(data: Partial<Item>[], opts?: MutationOptions) {
+		await this.assertCustomPermissionsEnabled(data);
 		const res = await super.createMany(data, opts);
 
 		await this.clearCaches(opts);
@@ -54,6 +81,7 @@ export class PermissionsService extends ItemsService {
 	}
 
 	override async updateBatch(data: Partial<Item>[], opts?: MutationOptions) {
+		await this.assertCustomPermissionsEnabled(data);
 		const res = await super.updateBatch(data, opts);
 
 		await this.clearCaches(opts);
@@ -62,6 +90,7 @@ export class PermissionsService extends ItemsService {
 	}
 
 	override async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts?: MutationOptions) {
+		await this.assertCustomPermissionsEnabled(data);
 		const res = await super.updateMany(keys, data, opts);
 
 		await this.clearCaches(opts);
@@ -70,6 +99,7 @@ export class PermissionsService extends ItemsService {
 	}
 
 	override async upsertMany(payloads: Partial<Item>[], opts?: MutationOptions) {
+		await this.assertCustomPermissionsEnabled(payloads);
 		const res = await super.upsertMany(payloads, opts);
 
 		await this.clearCaches(opts);

--- a/app/src/components/v-date-picker/v-date-picker.test.ts
+++ b/app/src/components/v-date-picker/v-date-picker.test.ts
@@ -601,16 +601,6 @@ describe('v-date-picker', () => {
 		});
 
 		it('clamps day when changing to month with fewer days', async () => {
-			let capturedDay: number | undefined;
-
-			vi.mocked(formatDatePickerModelValue).mockImplementation((_type, options) => {
-				if (options.calendarValue && 'day' in options.calendarValue) {
-					capturedDay = options.calendarValue.day;
-				}
-
-				return '2024-02-29';
-			});
-
 			// Start with January 31st
 			const wrapper = createWrapper({
 				type: 'date',
@@ -625,27 +615,15 @@ describe('v-date-picker', () => {
 			await monthSelect.trigger('change');
 			await nextTick();
 
-			// Trigger emission to capture the clamped value
-			const nowButton = wrapper.find('.calendar-today-button');
-			await nowButton.trigger('click');
-			await nextTick();
+			// Check calendarValue directly — do NOT use the now button, which overwrites calendarValue with today
+			const calendarValue = (wrapper.vm as any).$.setupState.calendarValue;
 
 			// Day should be clamped to 29 (max for Feb 2024)
-			expect(capturedDay).toBeDefined();
-			expect(capturedDay).toBeLessThanOrEqual(29);
+			expect(calendarValue).toBeDefined();
+			expect(calendarValue.day).toBeLessThanOrEqual(29);
 		});
 
 		it('clamps day when changing year affects leap year', async () => {
-			let capturedDay: number | undefined;
-
-			vi.mocked(formatDatePickerModelValue).mockImplementation((_type, options) => {
-				if (options.calendarValue && 'day' in options.calendarValue) {
-					capturedDay = options.calendarValue.day;
-				}
-
-				return '2023-02-28';
-			});
-
 			// Start with Feb 29 on a leap year
 			const wrapper = createWrapper({
 				type: 'date',
@@ -660,14 +638,12 @@ describe('v-date-picker', () => {
 			await yearInput.trigger('change');
 			await nextTick();
 
-			// Trigger emission to capture the clamped value
-			const nowButton = wrapper.find('.calendar-today-button');
-			await nowButton.trigger('click');
-			await nextTick();
+			// Check calendarValue directly — do NOT use the now button, which overwrites calendarValue with today
+			const calendarValue = (wrapper.vm as any).$.setupState.calendarValue;
 
 			// Day should be clamped to 28 (max for Feb 2023)
-			expect(capturedDay).toBeDefined();
-			expect(capturedDay).toBeLessThanOrEqual(28);
+			expect(calendarValue).toBeDefined();
+			expect(calendarValue.day).toBeLessThanOrEqual(28);
 		});
 
 		it('uses current date as fallback when no date is selected', async () => {


### PR DESCRIPTION
## Scope

What's changed:

- Implement `isCustomPermission` for validating if a Permission is from custom.
- Implement `assertCustomPermissionsEnabled` to check if the Directus License have feature `custom_permissions` enabled
- Applied `assertCustomPermissionsEnabled` in various functions for `PermissionService`
- Fix Unit Test error with `nowButton` keeping the current Date

## Tested Scenarios

- Must throw ForbiddenError when Create custom permission with feature disabled 
- Must throw ForbiddenError when Update custom permission with feature disabled
- Must not throw ForbiddenError when Create/read normal permission with feature disabled
- Custom Permissions must be filtered out when access GET /permissions
- Must throw ForbiddenError when accessing /items of a custom permission but the feature is disabled